### PR TITLE
Discord Presence Service (Lanyard-inspired)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,3 @@
-APP_HOST=0.0.0.0
 APP_PORT=3000
 BASE_URL=https://cdn.example.com
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <p align="center"><img src="assets/voidchan.png" alt="VoidChan Logo" width="200"/></p>
 
-**VoidChan** is a self-hosted file hosting and CDN-style upload service built in Rust. It provides authenticated uploads through a ShareX-compatible API, stores files in S3-compatible object storage (configured for Cloudflare R2), keeps file and user metadata in MySQL, and serves uploaded files through raw, download, and viewer-style URLs.
-
-It also includes a Discord bot layer for user registration, token management, profile/config controls, file lookup, and basic admin moderation like blacklisting users or deleting files.
+**VoidChan** is a multi-purpose service written in Rust for uploading and sharing files with ease using [ShareX](https://github.com/sharex/sharex). It integrates with Discord for account and file management, and includes a customisable Discord presence feature to showcase your activity.
 
 Join the Discord server: https://discord.gg/CqBf9vkD8m

--- a/migrations/0003_presence_api.sql
+++ b/migrations/0003_presence_api.sql
@@ -1,0 +1,11 @@
+CREATE TABLE user_presence_kv (
+    user_id BIGINT UNSIGNED NOT NULL,
+    kv_key VARCHAR(255) NOT NULL,
+    kv_value TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, kv_key),
+    CONSTRAINT fk_user_presence_kv_user
+        FOREIGN KEY (user_id) REFERENCES users(id)
+        ON DELETE CASCADE
+);

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1,11 +1,12 @@
 use aws_sdk_s3::Client as S3Client;
 use sqlx::MySqlPool;
 
-use crate::config::Config;
+use crate::{config::Config, presence::PresenceService};
 
 #[derive(Clone)]
 pub struct AppState {
     pub config: Config,
     pub db: MySqlPool,
     pub s3: S3Client,
+    pub presence: PresenceService,
 }

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -1,12 +1,13 @@
 use std::{collections::BTreeMap, sync::Arc};
 
+use chrono::{DateTime, Utc};
 use serenity::{
     all::{
         ButtonStyle, CommandDataOptionValue, CommandInteraction, CommandOptionType,
         ComponentInteraction, CreateActionRow, CreateButton, CreateCommand, CreateCommandOption,
-        CreateInteractionResponse, CreateInteractionResponseMessage, GatewayIntents, Guild,
-        GuildId, Interaction, Member, OnlineStatus, Permissions, Presence, Ready,
-        User as DiscordUser,
+        CreateEmbed, CreateEmbedAuthor, CreateEmbedFooter, CreateInteractionResponse,
+        CreateInteractionResponseMessage, GatewayIntents, Guild, GuildId, Interaction, Member,
+        OnlineStatus, Permissions, Presence, Ready, User as DiscordUser,
     },
     async_trait,
     client::{Client, Context, EventHandler},
@@ -190,35 +191,63 @@ impl Handler {
             let extension = row
                 .try_get::<String, _>("extension")
                 .unwrap_or_else(|_| "bin".to_string());
-            let message = format!(
-                "**File detail**
-ID: `{}`
-Name: {}
-Type: {}
-Size: {} bytes
-Uploader: {}
-Created: {}
-View: {}/v/{}.{}
-Raw: {}/u/{}.{}",
-                id,
-                row.try_get::<Option<String>, _>("original_name")
-                    .ok()
-                    .flatten()
-                    .unwrap_or_else(|| "(unknown)".to_string()),
-                row.try_get::<String, _>("mime_type").unwrap_or_default(),
-                row.try_get::<u64, _>("size").unwrap_or_default(),
-                row.try_get::<String, _>("uploader").unwrap_or_default(),
-                row.try_get::<chrono::NaiveDateTime, _>("created_at")
-                    .map(|v| v.to_string())
-                    .unwrap_or_default(),
-                self.state.config.base_url.trim_end_matches('/'),
-                file_id,
-                extension,
-                self.state.config.base_url.trim_end_matches('/'),
-                file_id,
-                extension,
-            );
-            respond_component(ctx, component, true, message).await?;
+            let embed = CreateEmbed::new()
+                .title("File detail")
+                .field("ID", format!("`{}`", id), true)
+                .field(
+                    "Name",
+                    row.try_get::<Option<String>, _>("original_name")
+                        .ok()
+                        .flatten()
+                        .unwrap_or_else(|| "(unknown)".to_string()),
+                    true,
+                )
+                .field(
+                    "Type",
+                    row.try_get::<String, _>("mime_type").unwrap_or_default(),
+                    true,
+                )
+                .field(
+                    "Size",
+                    format!(
+                        "{} bytes",
+                        row.try_get::<u64, _>("size").unwrap_or_default()
+                    ),
+                    true,
+                )
+                .field(
+                    "Uploader",
+                    row.try_get::<String, _>("uploader").unwrap_or_default(),
+                    true,
+                )
+                .field(
+                    "Created",
+                    row.try_get::<chrono::NaiveDateTime, _>("created_at")
+                        .map(|v| v.to_string())
+                        .unwrap_or_default(),
+                    false,
+                )
+                .field(
+                    "View URL",
+                    format!(
+                        "{}/v/{}.{}",
+                        self.state.config.base_url.trim_end_matches('/'),
+                        file_id,
+                        extension
+                    ),
+                    false,
+                )
+                .field(
+                    "Raw URL",
+                    format!(
+                        "{}/u/{}.{}",
+                        self.state.config.base_url.trim_end_matches('/'),
+                        file_id,
+                        extension
+                    ),
+                    false,
+                );
+            respond_component_embed(ctx, component, true, embed).await?;
             return Ok(());
         }
 
@@ -292,12 +321,18 @@ Raw: {}/u/{}.{}",
 
         let runners = shard_manager.runners.lock().await;
 
-        let content = match runners.get(&ctx.shard_id).and_then(|runner| runner.latency) {
-            Some(latency) => format!("Pong! `{}` ms", latency.as_millis()),
-            None => "Pong! Latency not available yet.".to_string(),
+        let embed = match runners.get(&ctx.shard_id).and_then(|runner| runner.latency) {
+            Some(latency) => CreateEmbed::new().title("Pong").field(
+                "Gateway latency",
+                format!("`{}` ms", latency.as_millis()),
+                false,
+            ),
+            None => CreateEmbed::new()
+                .title("Pong")
+                .description("Latency is not available yet."),
         };
 
-        respond(ctx, command, true, content).await?;
+        respond_embed(ctx, command, true, embed).await?;
         Ok(())
     }
 
@@ -408,14 +443,14 @@ Raw: {}/u/{}.{}",
             .execute(&self.state.db)
             .await?;
 
-        respond(
+        respond_embed(
             ctx,
             command,
             true,
-            format!(
-                "Updated config. URL mode: `/{}` | Hex colour: `{}`",
-                next_mode, next_colour
-            ),
+            CreateEmbed::new()
+                .title("Configuration updated")
+                .field("URL mode", format!("`/{}`", next_mode), true)
+                .field("Hex colour", format!("`{}`", next_colour), true),
         )
         .await?;
         Ok(())
@@ -469,7 +504,6 @@ Raw: {}/u/{}.{}",
             respond(ctx, command, true, "Register first with `/register`.").await?;
             return Ok(());
         };
-
         let total_uploads: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM files WHERE uploader_id = ?")
                 .bind(user.id)
@@ -481,16 +515,62 @@ Raw: {}/u/{}.{}",
                 .fetch_one(&self.state.db)
                 .await?;
 
-        respond(
-            ctx,
-            command,
-            true,
-            format!(
-                "**Profile**\nUsername: `{}`\nPreferred URL mode: `/{}`\nPreferred hex colour: `{}`\nTotal files uploaded: `{}`\nTotal KV entries: `{}`",
-                user.username, user.preferred_url_mode, user.preferred_hex_colour, total_uploads, total_kv_entries
-            ),
-        )
-        .await?;
+        let account_creation = DateTime::<Utc>::from_naive_utc_and_offset(user.created_at, Utc);
+        let embed = CreateEmbed::new()
+            .author(
+                CreateEmbedAuthor::new(format!("@{}", user.username)).icon_url(format!(
+                    "https://cdn.discordapp.com/avatars/{}/{}.png?size=256",
+                    command.user.id,
+                    command
+                        .user
+                        .avatar
+                        .as_ref()
+                        .map(|hash| hash.to_string())
+                        .unwrap_or("0".into())
+                )),
+            )
+            .title("Your Profile")
+            .field(
+                "VoidChan Account Creation",
+                format!("<t:{}:F>", account_creation.timestamp()),
+                false,
+            )
+            .field(
+                "Preferred URL Mode",
+                format!("`/{}`", user.preferred_url_mode),
+                true,
+            )
+            .field(
+                "Preferred Hex Colour",
+                format!("`{}`", user.preferred_hex_colour),
+                true,
+            )
+            .field(
+                "Total Files",
+                format!("```prolog\n{}```", total_uploads),
+                false,
+            )
+            .field(
+                "Total KV Entries",
+                format!("```prolog\n{}```", total_kv_entries),
+                false,
+            )
+            .thumbnail(format!(
+                "https://cdn.discordapp.com/avatars/{}/{}.png?size=256",
+                command.user.id,
+                command
+                    .user
+                    .avatar
+                    .as_ref()
+                    .map(|hash| hash.to_string())
+                    .unwrap_or("0".into()),
+            ))
+            .footer(CreateEmbedFooter::new(format!(
+                "ID: {}",
+                user.discord_user_id.unwrap_or_default()
+            )));
+
+        respond_embed(ctx, command, true, embed).await?;
         Ok(())
     }
 
@@ -500,14 +580,14 @@ Raw: {}/u/{}.{}",
             return Ok(());
         };
 
-        let (content, components) = self.render_files_page_for_user(user.id, 0).await?;
+        let (embed, components) = self.render_files_page_for_user(user.id, 0).await?;
 
         command
             .create_response(
                 &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .content(content)
+                        .add_embed(embed)
                         .ephemeral(true)
                         .components(components),
                 ),
@@ -525,13 +605,13 @@ Raw: {}/u/{}.{}",
         };
 
         let Some(option) = command.data.options.first() else {
-            let (content, components) = self.render_kv_page_for_user(user.id, 0).await?;
+            let (embed, components) = self.render_kv_page_for_user(user.id, 0).await?;
             command
                 .create_response(
                     &ctx.http,
                     CreateInteractionResponse::Message(
                         CreateInteractionResponseMessage::new()
-                            .content(content)
+                            .add_embed(embed)
                             .ephemeral(true)
                             .components(components),
                     ),
@@ -585,14 +665,18 @@ Raw: {}/u/{}.{}",
                 .execute(&self.state.db)
                 .await?;
 
-                respond(
+                respond_embed(
                     ctx,
                     command,
                     true,
-                    format!(
-                        "Stored KV entry `{key}` with {} character(s).",
-                        value.chars().count()
-                    ),
+                    CreateEmbed::new()
+                        .title("KV Entry Stored")
+                        .field("Key", format!("`{key}`"), true)
+                        .field(
+                            "Length",
+                            format!("`{}` character(s)", value.chars().count()),
+                            true,
+                        ),
                 )
                 .await?;
             }
@@ -627,24 +711,51 @@ Raw: {}/u/{}.{}",
 
                     if let Some(row) = row {
                         let value = row.try_get::<String, _>("kv_value").unwrap_or_default();
-                        respond(ctx, command, true, format!("`{key}` = ```\n{value}\n```")).await?;
-                    } else {
-                        respond(
+                        let value_len = value.chars().count();
+                        let display_value = if value_len > 1000 {
+                            format!("{}...", value.chars().take(1000).collect::<String>())
+                        } else {
+                            value
+                        };
+
+                        respond_embed(
                             ctx,
                             command,
                             true,
-                            format!("No KV entry found for `{key}`."),
+                            CreateEmbed::new()
+                                .title("KV Entry")
+                                .field("Key", format!("`{key}`"), true)
+                                .field("Length", format!("`{value_len}` character(s)"), true)
+                                .field(
+                                    "Value",
+                                    format!(
+                                        "```
+{display_value}
+```"
+                                    ),
+                                    false,
+                                ),
+                        )
+                        .await?;
+                    } else {
+                        respond_embed(
+                            ctx,
+                            command,
+                            true,
+                            CreateEmbed::new()
+                                .title("KV Entry Not Found")
+                                .description(format!("No KV entry found for `{key}`.")),
                         )
                         .await?;
                     }
                 } else {
-                    let (content, components) = self.render_kv_page_for_user(user.id, 0).await?;
+                    let (embed, components) = self.render_kv_page_for_user(user.id, 0).await?;
                     command
                         .create_response(
                             &ctx.http,
                             CreateInteractionResponse::Message(
                                 CreateInteractionResponseMessage::new()
-                                    .content(content)
+                                    .add_embed(embed)
                                     .ephemeral(true)
                                     .components(components),
                             ),
@@ -659,19 +770,21 @@ Raw: {}/u/{}.{}",
                     .execute(&self.state.db)
                     .await?;
 
-                respond(
+                respond_embed(
                     ctx,
                     command,
                     true,
-                    format!(
-                        "Cleared `{}` KV entr{}.",
-                        result.rows_affected(),
-                        if result.rows_affected() == 1 {
-                            "y"
-                        } else {
-                            "ies"
-                        }
-                    ),
+                    CreateEmbed::new()
+                        .title("KV Entry Cleared")
+                        .description(format!(
+                            "Cleared `{}` KV entr{}.",
+                            result.rows_affected(),
+                            if result.rows_affected() == 1 {
+                                "y"
+                            } else {
+                                "ies"
+                            }
+                        )),
                 )
                 .await?;
             }
@@ -749,15 +862,25 @@ Raw: {}/u/{}.{}",
                         .await?;
 
                 if result.rows_affected() == 0 {
-                    respond(
+                    respond_embed(
                         ctx,
                         command,
                         true,
-                        format!("No KV entry found for `{key}`."),
+                        CreateEmbed::new()
+                            .title("KV Entry Not Found")
+                            .description(format!("No KV entry found for `{key}`.")),
                     )
                     .await?;
                 } else {
-                    respond(ctx, command, true, format!("Deleted KV entry `{key}`.")).await?;
+                    respond_embed(
+                        ctx,
+                        command,
+                        true,
+                        CreateEmbed::new()
+                            .title("KV Entry Deleted")
+                            .description(format!("Deleted KV entry `{key}`.")),
+                    )
+                    .await?;
                 }
             }
             _ => {
@@ -792,7 +915,7 @@ Raw: {}/u/{}.{}",
         .fetch_all(&self.state.db)
         .await?;
 
-        let mut lines = vec!["**Users**".to_string()];
+        let mut lines = Vec::new();
         for row in rows {
             lines.push(format!(
                 "• `{}` | Discord: `{}` | mode `/{}` | colour `{}` | uploads `{}` | blacklisted `{}`",
@@ -805,7 +928,15 @@ Raw: {}/u/{}.{}",
             ));
         }
 
-        respond(ctx, command, true, lines.join("\n")).await?;
+        respond_embed(
+            ctx,
+            command,
+            true,
+            CreateEmbed::new()
+                .title("Users")
+                .description(lines.join("\n")),
+        )
+        .await?;
         Ok(())
     }
 
@@ -819,14 +950,14 @@ Raw: {}/u/{}.{}",
             return Ok(());
         }
 
-        let (content, components) = self.render_admin_files_page(0).await?;
+        let (embed, components) = self.render_admin_files_page(0).await?;
 
         command
             .create_response(
                 &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .content(content)
+                        .add_embed(embed)
                         .ephemeral(true)
                         .components(components),
                 ),
@@ -872,11 +1003,14 @@ Raw: {}/u/{}.{}",
             return Ok(());
         }
 
-        respond(
+        respond_embed(
             ctx,
             command,
             true,
-            format!("Updated blacklist for `{discord_user_id}` to `{blacklisted}`."),
+            CreateEmbed::new()
+                .title("Blacklist updated")
+                .field("Discord user ID", format!("`{discord_user_id}`"), true)
+                .field("Blacklisted", format!("`{blacklisted}`"), true),
         )
         .await?;
         Ok(())
@@ -932,7 +1066,15 @@ Raw: {}/u/{}.{}",
             .execute(&self.state.db)
             .await?;
 
-        respond(ctx, command, true, format!("Deleted file `{file_id}`.")).await?;
+        respond_embed(
+            ctx,
+            command,
+            true,
+            CreateEmbed::new()
+                .title("File deleted")
+                .description(format!("Deleted file `{file_id}`.")),
+        )
+        .await?;
         Ok(())
     }
 
@@ -940,7 +1082,7 @@ Raw: {}/u/{}.{}",
         &self,
         user_id: u64,
         page: u64,
-    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+    ) -> Result<(CreateEmbed, Vec<CreateActionRow>), AppError> {
         let total_files: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM files WHERE uploader_id = ?")
                 .bind(user_id)
@@ -951,7 +1093,9 @@ Raw: {}/u/{}.{}",
         let total_pages = total_pages(total_files, page_size);
         if total_pages == 0 {
             return Ok((
-                "You have not uploaded any files yet.".to_string(),
+                CreateEmbed::new()
+                    .title("Your uploaded files")
+                    .description("You have not uploaded any files yet."),
                 Vec::new(),
             ));
         }
@@ -973,11 +1117,7 @@ Raw: {}/u/{}.{}",
         .fetch_all(&self.state.db)
         .await?;
 
-        let mut lines = vec![format!(
-            "**Your uploaded files** (page {}/{})",
-            current_page + 1,
-            total_pages
-        )];
+        let mut lines = Vec::new();
         for row in rows {
             let id: String = row.try_get("id").unwrap_or_default();
             let extension = row.try_get::<String, _>("extension").unwrap_or_default();
@@ -996,12 +1136,23 @@ Raw: {}/u/{}.{}",
                 id,
                 extension
             );
-            lines.push(format!("• `{}` — {} — {}", id, name, url));
-            lines.push(format!("  Uploaded: {}", created));
+            lines.push(format!(
+                "• `{}` — {}
+  URL: {}
+  Uploaded: {}",
+                id, name, url, created
+            ));
         }
 
         Ok((
-            lines.join("\n"),
+            CreateEmbed::new()
+                .title("Your uploaded files")
+                .description(lines.join("\n\n"))
+                .footer(serenity::builder::CreateEmbedFooter::new(format!(
+                    "Page {}/{}",
+                    current_page + 1,
+                    total_pages
+                ))),
             owned_pagination_components("files", user_id, current_page, total_pages),
         ))
     }
@@ -1010,7 +1161,7 @@ Raw: {}/u/{}.{}",
         &self,
         user_id: u64,
         page: u64,
-    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+    ) -> Result<(CreateEmbed, Vec<CreateActionRow>), AppError> {
         let total_rows: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM user_presence_kv WHERE user_id = ?")
                 .bind(user_id)
@@ -1020,7 +1171,12 @@ Raw: {}/u/{}.{}",
         let page_size = 20_u64;
         let total_pages = total_pages(total_rows, page_size);
         if total_pages == 0 {
-            return Ok(("You have no KV entries yet.".to_string(), Vec::new()));
+            return Ok((
+                CreateEmbed::new()
+                    .title("Your KV Keys")
+                    .description("You have no KV entries yet."),
+                Vec::new(),
+            ));
         }
 
         let current_page = clamp_page(page, total_pages);
@@ -1040,12 +1196,7 @@ Raw: {}/u/{}.{}",
         .fetch_all(&self.state.db)
         .await?;
 
-        let mut lines = vec![format!(
-            "**Your KV keys** (page {}/{}, total {})",
-            current_page + 1,
-            total_pages,
-            total_rows
-        )];
+        let mut lines = Vec::new();
         for row in rows {
             lines.push(format!(
                 "• `{}`",
@@ -1054,7 +1205,15 @@ Raw: {}/u/{}.{}",
         }
 
         Ok((
-            lines.join("\n"),
+            CreateEmbed::new()
+                .title("Your KV Keys")
+                .description(lines.join("\n"))
+                .footer(serenity::builder::CreateEmbedFooter::new(format!(
+                    "Page {}/{} • Total {}",
+                    current_page + 1,
+                    total_pages,
+                    total_rows
+                ))),
             owned_pagination_components("kv", user_id, current_page, total_pages),
         ))
     }
@@ -1062,7 +1221,7 @@ Raw: {}/u/{}.{}",
     async fn render_admin_files_page(
         &self,
         page: u64,
-    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+    ) -> Result<(CreateEmbed, Vec<CreateActionRow>), AppError> {
         let total_files: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM files")
             .fetch_one(&self.state.db)
             .await?;
@@ -1070,7 +1229,12 @@ Raw: {}/u/{}.{}",
         let page_size = 10_u64;
         let total_pages = total_pages(total_files, page_size);
         if total_pages == 0 {
-            return Ok(("No uploaded files found.".to_string(), Vec::new()));
+            return Ok((
+                CreateEmbed::new()
+                    .title("Recent Uploaded Files")
+                    .description("No uploaded files found."),
+                Vec::new(),
+            ));
         }
 
         let current_page = clamp_page(page, total_pages);
@@ -1088,11 +1252,7 @@ Raw: {}/u/{}.{}",
         .fetch_all(&self.state.db)
         .await?;
 
-        let mut content = vec![format!(
-            "**Recent uploaded files** (page {}/{})",
-            current_page + 1,
-            total_pages
-        )];
+        let mut content = Vec::new();
         let mut buttons: Vec<CreateButton> = Vec::new();
         for row in rows {
             let id: String = row.try_get("id").unwrap_or_default();
@@ -1128,7 +1288,20 @@ Raw: {}/u/{}.{}",
             components.push(nav);
         }
 
-        Ok((content.join("\n"), components))
+        Ok((
+            CreateEmbed::new()
+                .title("Recent Uploaded Files")
+                .description(content.join(
+                    "
+",
+                ))
+                .footer(serenity::builder::CreateEmbedFooter::new(format!(
+                    "Page {}/{}",
+                    current_page + 1,
+                    total_pages
+                ))),
+            components,
+        ))
     }
 
     async fn get_registered_user(&self, discord_user_id: u64) -> Result<Option<User>, AppError> {
@@ -1275,6 +1448,44 @@ async fn respond_component(
             CreateInteractionResponse::Message(
                 CreateInteractionResponseMessage::new()
                     .content(content.into())
+                    .ephemeral(ephemeral),
+            ),
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+
+async fn respond_embed(
+    ctx: &Context,
+    command: &CommandInteraction,
+    ephemeral: bool,
+    embed: CreateEmbed,
+) -> Result<(), AppError> {
+    command
+        .create_response(
+            &ctx.http,
+            CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .add_embed(embed)
+                    .ephemeral(ephemeral),
+            ),
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+
+async fn respond_component_embed(
+    ctx: &Context,
+    component: &ComponentInteraction,
+    ephemeral: bool,
+    embed: CreateEmbed,
+) -> Result<(), AppError> {
+    component
+        .create_response(
+            &ctx.http,
+            CreateInteractionResponse::Message(
+                CreateInteractionResponseMessage::new()
+                    .add_embed(embed)
                     .ephemeral(ephemeral),
             ),
         )
@@ -1507,7 +1718,7 @@ fn update_disabled(button: CreateButton, disabled: bool) -> CreateButton {
 async fn update_component(
     ctx: &Context,
     component: &ComponentInteraction,
-    content: impl Into<String>,
+    embed: CreateEmbed,
     components: Vec<CreateActionRow>,
 ) -> Result<(), AppError> {
     component
@@ -1515,7 +1726,7 @@ async fn update_component(
             &ctx.http,
             CreateInteractionResponse::UpdateMessage(
                 CreateInteractionResponseMessage::new()
-                    .content(content.into())
+                    .embeds(vec![embed])
                     .components(components),
             ),
         )

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -1,11 +1,11 @@
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 use serenity::{
     all::{
         ButtonStyle, CommandDataOptionValue, CommandInteraction, CommandOptionType,
         ComponentInteraction, CreateActionRow, CreateButton, CreateCommand, CreateCommandOption,
-        CreateInteractionResponse, CreateInteractionResponseMessage, GatewayIntents, Guild, GuildId,
-        Interaction, Member, OnlineStatus, Permissions, Presence, Ready,
+        CreateInteractionResponse, CreateInteractionResponseMessage, GatewayIntents, Guild,
+        GuildId, Interaction, Member, OnlineStatus, Permissions, Presence, Ready,
         User as DiscordUser,
     },
     async_trait,
@@ -61,6 +61,7 @@ impl EventHandler for Handler {
             token_command(),
             profile_command(),
             files_command(),
+            kv_command(),
             admin_users_command(),
             admin_files_command(),
             blacklist_command(),
@@ -148,6 +149,7 @@ impl Handler {
             "token" => self.token(ctx, command).await,
             "profile" => self.profile(ctx, command).await,
             "files" => self.files(ctx, command).await,
+            "kv" => self.kv(ctx, command).await,
             "admin_users" => self.admin_users(ctx, command).await,
             "admin_files" => self.admin_files(ctx, command).await,
             "blacklist" => self.blacklist(ctx, command).await,
@@ -161,12 +163,13 @@ impl Handler {
         ctx: &Context,
         component: &ComponentInteraction,
     ) -> Result<(), AppError> {
-        if !is_admin(component.member.as_ref().and_then(|m| m.permissions)) {
-            respond_component(ctx, component, true, "Administrator permission required.").await?;
-            return Ok(());
-        }
-
         if let Some(file_id) = component.data.custom_id.strip_prefix("file_detail:") {
+            if !is_admin(component.member.as_ref().and_then(|m| m.permissions)) {
+                respond_component(ctx, component, true, "Administrator permission required.")
+                    .await?;
+                return Ok(());
+            }
+
             let row = sqlx::query(
                 r#"
                 SELECT f.id, f.original_name, f.mime_type, f.extension, f.size, f.uploader, f.created_at
@@ -216,6 +219,64 @@ Raw: {}/u/{}.{}",
                 extension,
             );
             respond_component(ctx, component, true, message).await?;
+            return Ok(());
+        }
+
+        if let Some((kind, owner_id, page)) = parse_owned_page_custom_id(&component.data.custom_id)
+        {
+            if component.user.id.get().to_string() != owner_id {
+                respond_component(
+                    ctx,
+                    component,
+                    true,
+                    "This paginator belongs to another user.",
+                )
+                .await?;
+                return Ok(());
+            }
+
+            match kind {
+                "files" => {
+                    let (content, components) = self
+                        .render_files_page_for_user(
+                            owner_id
+                                .parse::<u64>()
+                                .map_err(|_| AppError::BadRequest("Invalid paginator owner."))?,
+                            page,
+                        )
+                        .await?;
+                    update_component(ctx, component, content, components).await?;
+                    return Ok(());
+                }
+                "kv" => {
+                    let (content, components) = self
+                        .render_kv_page_for_user(
+                            owner_id
+                                .parse::<u64>()
+                                .map_err(|_| AppError::BadRequest("Invalid paginator owner."))?,
+                            page,
+                        )
+                        .await?;
+                    update_component(ctx, component, content, components).await?;
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
+        if let Some(page) = component.data.custom_id.strip_prefix("page:admin_files:") {
+            if !is_admin(component.member.as_ref().and_then(|m| m.permissions)) {
+                respond_component(ctx, component, true, "Administrator permission required.")
+                    .await?;
+                return Ok(());
+            }
+
+            let page = page
+                .parse::<u64>()
+                .map_err(|_| AppError::BadRequest("Invalid page."))?;
+            let (content, components) = self.render_admin_files_page(page).await?;
+            update_component(ctx, component, content, components).await?;
+            return Ok(());
         }
 
         Ok(())
@@ -414,14 +475,19 @@ Raw: {}/u/{}.{}",
                 .bind(user.id)
                 .fetch_one(&self.state.db)
                 .await?;
+        let total_kv_entries: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user_presence_kv WHERE user_id = ?")
+                .bind(user.id)
+                .fetch_one(&self.state.db)
+                .await?;
 
         respond(
             ctx,
             command,
             true,
             format!(
-                "**Profile**\nUsername: `{}`\nPreferred URL mode: `/{}`\nPreferred hex colour: `{}`\nTotal files uploaded: `{}`",
-                user.username, user.preferred_url_mode, user.preferred_hex_colour, total_uploads
+                "**Profile**\nUsername: `{}`\nPreferred URL mode: `/{}`\nPreferred hex colour: `{}`\nTotal files uploaded: `{}`\nTotal KV entries: `{}`",
+                user.username, user.preferred_url_mode, user.preferred_hex_colour, total_uploads, total_kv_entries
             ),
         )
         .await?;
@@ -434,53 +500,271 @@ Raw: {}/u/{}.{}",
             return Ok(());
         };
 
-        let rows = sqlx::query(
-            r#"
-            SELECT id, original_name, extension, created_at
-            FROM files
-            WHERE uploader_id = ?
-            ORDER BY created_at DESC
-            LIMIT 20
-            "#,
-        )
-        .bind(user.id)
-        .fetch_all(&self.state.db)
-        .await?;
+        let (content, components) = self.render_files_page_for_user(user.id, 0).await?;
 
-        if rows.is_empty() {
-            respond(ctx, command, true, "You have not uploaded any files yet.").await?;
+        command
+            .create_response(
+                &ctx.http,
+                CreateInteractionResponse::Message(
+                    CreateInteractionResponseMessage::new()
+                        .content(content)
+                        .ephemeral(true)
+                        .components(components),
+                ),
+            )
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn kv(&self, ctx: &Context, command: &CommandInteraction) -> Result<(), AppError> {
+        let Some(user) = self.get_registered_user(command.user.id.get()).await? else {
+            respond(ctx, command, true, "Register first with `/register`.").await?;
             return Ok(());
-        }
+        };
 
-        let mut lines = vec!["**Your uploaded files**".to_string()];
-        for row in rows {
-            let id: String = row.try_get("id").unwrap_or_default();
-            let name = row
-                .try_get::<Option<String>, _>("original_name")
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| {
+        let Some(option) = command.data.options.first() else {
+            let (content, components) = self.render_kv_page_for_user(user.id, 0).await?;
+            command
+                .create_response(
+                    &ctx.http,
+                    CreateInteractionResponse::Message(
+                        CreateInteractionResponseMessage::new()
+                            .content(content)
+                            .ephemeral(true)
+                            .components(components),
+                    ),
+                )
+                .await
+                .map_err(|e| AppError::Internal(e.to_string()))?;
+            return Ok(());
+        };
+
+        match option.name.as_str() {
+            "set" => {
+                let mut key = None::<String>;
+                let mut value = None::<String>;
+
+                if let CommandDataOptionValue::SubCommand(sub_options) = &option.value {
+                    for sub_option in sub_options {
+                        match (sub_option.name.as_str(), &sub_option.value) {
+                            ("key", CommandDataOptionValue::String(v)) => key = Some(v.to_string()),
+                            ("value", CommandDataOptionValue::String(v)) => {
+                                value = Some(v.to_string())
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+
+                let Some(key) = key else {
+                    respond(ctx, command, true, "Missing `key`.").await?;
+                    return Ok(());
+                };
+
+                let Some(value) = value else {
+                    respond(ctx, command, true, "Missing `value`.").await?;
+                    return Ok(());
+                };
+
+                validate_kv_key(&key)?;
+                validate_kv_value(&value)?;
+                ensure_kv_capacity(&self.state, user.id, &[key.clone()]).await?;
+
+                sqlx::query(
+                    r#"
+                    INSERT INTO user_presence_kv (user_id, kv_key, kv_value)
+                    VALUES (?, ?, ?)
+                    ON DUPLICATE KEY UPDATE kv_value = VALUES(kv_value), updated_at = UTC_TIMESTAMP()
+                    "#,
+                )
+                .bind(user.id)
+                .bind(&key)
+                .bind(&value)
+                .execute(&self.state.db)
+                .await?;
+
+                respond(
+                    ctx,
+                    command,
+                    true,
                     format!(
-                        "{}.{}",
-                        id,
-                        row.try_get::<String, _>("extension").unwrap_or_default()
+                        "Stored KV entry `{key}` with {} character(s).",
+                        value.chars().count()
+                    ),
+                )
+                .await?;
+            }
+            "get" => {
+                let mut key = None::<String>;
+
+                if let CommandDataOptionValue::SubCommand(sub_options) = &option.value {
+                    for sub_option in sub_options {
+                        if let ("key", CommandDataOptionValue::String(v)) =
+                            (sub_option.name.as_str(), &sub_option.value)
+                        {
+                            key = Some(v.to_string());
+                        }
+                    }
+                }
+
+                if let Some(key) = key {
+                    validate_kv_key(&key)?;
+
+                    let row = sqlx::query(
+                        r#"
+                        SELECT kv_value
+                        FROM user_presence_kv
+                        WHERE user_id = ? AND kv_key = ?
+                        LIMIT 1
+                        "#,
                     )
-                });
-            let created = row
-                .try_get::<chrono::NaiveDateTime, _>("created_at")
-                .map(|v| v.to_string())
-                .unwrap_or_default();
-            let url = format!(
-                "{}/v/{}.{}",
-                self.state.config.base_url.trim_end_matches('/'),
-                id,
-                row.try_get::<String, _>("extension").unwrap_or_default()
-            );
-            lines.push(format!("• `{}` — {} — {}", id, name, url));
-            lines.push(format!("  Uploaded: {}", created));
+                    .bind(user.id)
+                    .bind(&key)
+                    .fetch_optional(&self.state.db)
+                    .await?;
+
+                    if let Some(row) = row {
+                        let value = row.try_get::<String, _>("kv_value").unwrap_or_default();
+                        respond(ctx, command, true, format!("`{key}` = ```\n{value}\n```")).await?;
+                    } else {
+                        respond(
+                            ctx,
+                            command,
+                            true,
+                            format!("No KV entry found for `{key}`."),
+                        )
+                        .await?;
+                    }
+                } else {
+                    let (content, components) = self.render_kv_page_for_user(user.id, 0).await?;
+                    command
+                        .create_response(
+                            &ctx.http,
+                            CreateInteractionResponse::Message(
+                                CreateInteractionResponseMessage::new()
+                                    .content(content)
+                                    .ephemeral(true)
+                                    .components(components),
+                            ),
+                        )
+                        .await
+                        .map_err(|e| AppError::Internal(e.to_string()))?;
+                }
+            }
+            "clear" => {
+                let result = sqlx::query("DELETE FROM user_presence_kv WHERE user_id = ?")
+                    .bind(user.id)
+                    .execute(&self.state.db)
+                    .await?;
+
+                respond(
+                    ctx,
+                    command,
+                    true,
+                    format!(
+                        "Cleared `{}` KV entr{}.",
+                        result.rows_affected(),
+                        if result.rows_affected() == 1 {
+                            "y"
+                        } else {
+                            "ies"
+                        }
+                    ),
+                )
+                .await?;
+            }
+            "export" => {
+                let rows = sqlx::query(
+                    r#"
+                    SELECT kv_key, kv_value
+                    FROM user_presence_kv
+                    WHERE user_id = ?
+                    ORDER BY kv_key ASC
+                    "#,
+                )
+                .bind(user.id)
+                .fetch_all(&self.state.db)
+                .await?;
+
+                if rows.is_empty() {
+                    respond(ctx, command, true, "You have no KV entries yet.").await?;
+                    return Ok(());
+                }
+
+                let mut payload = BTreeMap::new();
+                for row in rows {
+                    payload.insert(
+                        row.try_get::<String, _>("kv_key").unwrap_or_default(),
+                        row.try_get::<String, _>("kv_value").unwrap_or_default(),
+                    );
+                }
+
+                let json = serde_json::to_string_pretty(&payload).map_err(|e| {
+                    AppError::Internal(format!("Failed to serialize KV export: {e}"))
+                })?;
+                let wrapped = format!("```json\n{}\n```", json);
+
+                if wrapped.chars().count() > 1900 {
+                    respond(
+                        ctx,
+                        command,
+                        true,
+                        format!(
+                            "KV export is too large to fit in a Discord message ({} characters).",
+                            wrapped.chars().count()
+                        ),
+                    )
+                    .await?;
+                } else {
+                    respond(ctx, command, true, wrapped).await?;
+                }
+            }
+            "delete" => {
+                let mut key = None::<String>;
+
+                if let CommandDataOptionValue::SubCommand(sub_options) = &option.value {
+                    for sub_option in sub_options {
+                        if let ("key", CommandDataOptionValue::String(v)) =
+                            (sub_option.name.as_str(), &sub_option.value)
+                        {
+                            key = Some(v.to_string());
+                        }
+                    }
+                }
+
+                let Some(key) = key else {
+                    respond(ctx, command, true, "Missing `key`.").await?;
+                    return Ok(());
+                };
+
+                validate_kv_key(&key)?;
+
+                let result =
+                    sqlx::query("DELETE FROM user_presence_kv WHERE user_id = ? AND kv_key = ?")
+                        .bind(user.id)
+                        .bind(&key)
+                        .execute(&self.state.db)
+                        .await?;
+
+                if result.rows_affected() == 0 {
+                    respond(
+                        ctx,
+                        command,
+                        true,
+                        format!("No KV entry found for `{key}`."),
+                    )
+                    .await?;
+                } else {
+                    respond(ctx, command, true, format!("Deleted KV entry `{key}`.")).await?;
+                }
+            }
+            _ => {
+                respond(ctx, command, true, "Use `/kv get [key]`, `/kv set <key> <value>`, `/kv delete <key>`, `/kv clear`, or `/kv export`." ).await?;
+            }
         }
 
-        respond(ctx, command, true, lines.join("\n")).await?;
         Ok(())
     }
 
@@ -535,63 +819,16 @@ Raw: {}/u/{}.{}",
             return Ok(());
         }
 
-        let rows = sqlx::query(
-            r#"
-            SELECT id, original_name, extension, uploader
-            FROM files
-            ORDER BY created_at DESC
-            LIMIT 10
-            "#,
-        )
-        .fetch_all(&self.state.db)
-        .await?;
-
-        if rows.is_empty() {
-            respond(ctx, command, true, "No uploaded files found.").await?;
-            return Ok(());
-        }
-
-        let mut content = vec!["**Recent uploaded files**".to_string()];
-        let mut buttons: Vec<CreateButton> = Vec::new();
-        for row in rows {
-            let id: String = row.try_get("id").unwrap_or_default();
-            let label = row
-                .try_get::<Option<String>, _>("original_name")
-                .ok()
-                .flatten()
-                .unwrap_or_else(|| {
-                    format!(
-                        "{}.{}",
-                        id,
-                        row.try_get::<String, _>("extension").unwrap_or_default()
-                    )
-                });
-            content.push(format!(
-                "• `{}` — {} — uploader `{}`",
-                id,
-                label,
-                row.try_get::<String, _>("uploader").unwrap_or_default()
-            ));
-            buttons.push(
-                CreateButton::new(format!("file_detail:{id}"))
-                    .label(format!("Detail {id}"))
-                    .style(ButtonStyle::Primary),
-            );
-        }
-
-        let rows = chunk_buttons(buttons)
-            .into_iter()
-            .map(CreateActionRow::Buttons)
-            .collect::<Vec<_>>();
+        let (content, components) = self.render_admin_files_page(0).await?;
 
         command
             .create_response(
                 &ctx.http,
                 CreateInteractionResponse::Message(
                     CreateInteractionResponseMessage::new()
-                        .content(content.join("\n"))
+                        .content(content)
                         .ephemeral(true)
-                        .components(rows),
+                        .components(components),
                 ),
             )
             .await
@@ -699,6 +936,201 @@ Raw: {}/u/{}.{}",
         Ok(())
     }
 
+    async fn render_files_page_for_user(
+        &self,
+        user_id: u64,
+        page: u64,
+    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+        let total_files: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM files WHERE uploader_id = ?")
+                .bind(user_id)
+                .fetch_one(&self.state.db)
+                .await?;
+
+        let page_size = 10_u64;
+        let total_pages = total_pages(total_files, page_size);
+        if total_pages == 0 {
+            return Ok((
+                "You have not uploaded any files yet.".to_string(),
+                Vec::new(),
+            ));
+        }
+
+        let current_page = clamp_page(page, total_pages);
+        let offset = (current_page * page_size) as i64;
+        let rows = sqlx::query(
+            r#"
+            SELECT id, original_name, extension, created_at
+            FROM files
+            WHERE uploader_id = ?
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            "#,
+        )
+        .bind(user_id)
+        .bind(page_size as i64)
+        .bind(offset)
+        .fetch_all(&self.state.db)
+        .await?;
+
+        let mut lines = vec![format!(
+            "**Your uploaded files** (page {}/{})",
+            current_page + 1,
+            total_pages
+        )];
+        for row in rows {
+            let id: String = row.try_get("id").unwrap_or_default();
+            let extension = row.try_get::<String, _>("extension").unwrap_or_default();
+            let name = row
+                .try_get::<Option<String>, _>("original_name")
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| format!("{}.{}", id, extension));
+            let created = row
+                .try_get::<chrono::NaiveDateTime, _>("created_at")
+                .map(|v| v.to_string())
+                .unwrap_or_default();
+            let url = format!(
+                "{}/v/{}.{}",
+                self.state.config.base_url.trim_end_matches('/'),
+                id,
+                extension
+            );
+            lines.push(format!("• `{}` — {} — {}", id, name, url));
+            lines.push(format!("  Uploaded: {}", created));
+        }
+
+        Ok((
+            lines.join("\n"),
+            owned_pagination_components("files", user_id, current_page, total_pages),
+        ))
+    }
+
+    async fn render_kv_page_for_user(
+        &self,
+        user_id: u64,
+        page: u64,
+    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+        let total_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM user_presence_kv WHERE user_id = ?")
+                .bind(user_id)
+                .fetch_one(&self.state.db)
+                .await?;
+
+        let page_size = 20_u64;
+        let total_pages = total_pages(total_rows, page_size);
+        if total_pages == 0 {
+            return Ok(("You have no KV entries yet.".to_string(), Vec::new()));
+        }
+
+        let current_page = clamp_page(page, total_pages);
+        let offset = (current_page * page_size) as i64;
+        let rows = sqlx::query(
+            r#"
+            SELECT kv_key
+            FROM user_presence_kv
+            WHERE user_id = ?
+            ORDER BY kv_key ASC
+            LIMIT ? OFFSET ?
+            "#,
+        )
+        .bind(user_id)
+        .bind(page_size as i64)
+        .bind(offset)
+        .fetch_all(&self.state.db)
+        .await?;
+
+        let mut lines = vec![format!(
+            "**Your KV keys** (page {}/{}, total {})",
+            current_page + 1,
+            total_pages,
+            total_rows
+        )];
+        for row in rows {
+            lines.push(format!(
+                "• `{}`",
+                row.try_get::<String, _>("kv_key").unwrap_or_default()
+            ));
+        }
+
+        Ok((
+            lines.join("\n"),
+            owned_pagination_components("kv", user_id, current_page, total_pages),
+        ))
+    }
+
+    async fn render_admin_files_page(
+        &self,
+        page: u64,
+    ) -> Result<(String, Vec<CreateActionRow>), AppError> {
+        let total_files: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM files")
+            .fetch_one(&self.state.db)
+            .await?;
+
+        let page_size = 10_u64;
+        let total_pages = total_pages(total_files, page_size);
+        if total_pages == 0 {
+            return Ok(("No uploaded files found.".to_string(), Vec::new()));
+        }
+
+        let current_page = clamp_page(page, total_pages);
+        let offset = (current_page * page_size) as i64;
+        let rows = sqlx::query(
+            r#"
+            SELECT id, original_name, extension, uploader
+            FROM files
+            ORDER BY created_at DESC
+            LIMIT ? OFFSET ?
+            "#,
+        )
+        .bind(page_size as i64)
+        .bind(offset)
+        .fetch_all(&self.state.db)
+        .await?;
+
+        let mut content = vec![format!(
+            "**Recent uploaded files** (page {}/{})",
+            current_page + 1,
+            total_pages
+        )];
+        let mut buttons: Vec<CreateButton> = Vec::new();
+        for row in rows {
+            let id: String = row.try_get("id").unwrap_or_default();
+            let label = row
+                .try_get::<Option<String>, _>("original_name")
+                .ok()
+                .flatten()
+                .unwrap_or_else(|| {
+                    format!(
+                        "{}.{}",
+                        id,
+                        row.try_get::<String, _>("extension").unwrap_or_default()
+                    )
+                });
+            content.push(format!(
+                "• `{}` — {} — uploader `{}`",
+                id,
+                label,
+                row.try_get::<String, _>("uploader").unwrap_or_default()
+            ));
+            buttons.push(
+                CreateButton::new(format!("file_detail:{id}"))
+                    .label(format!("Detail {id}"))
+                    .style(ButtonStyle::Primary),
+            );
+        }
+
+        let mut components = chunk_buttons(buttons)
+            .into_iter()
+            .map(CreateActionRow::Buttons)
+            .collect::<Vec<_>>();
+        if let Some(nav) = admin_files_pagination_row(current_page, total_pages) {
+            components.push(nav);
+        }
+
+        Ok((content.join("\n"), components))
+    }
+
     async fn get_registered_user(&self, discord_user_id: u64) -> Result<Option<User>, AppError> {
         query_as::<_, User>(
             r#"
@@ -750,6 +1182,60 @@ Raw: {}/u/{}.{}",
 
         Ok(fallback)
     }
+}
+
+async fn ensure_kv_capacity(
+    state: &AppState,
+    user_id: u64,
+    candidate_keys: &[String],
+) -> Result<(), AppError> {
+    let existing_keys =
+        sqlx::query_as::<_, (String,)>("SELECT kv_key FROM user_presence_kv WHERE user_id = ?")
+            .bind(user_id)
+            .fetch_all(&state.db)
+            .await?;
+
+    let mut all_keys = existing_keys
+        .into_iter()
+        .map(|(key,)| key)
+        .collect::<std::collections::HashSet<_>>();
+
+    for key in candidate_keys {
+        all_keys.insert(key.clone());
+    }
+
+    if all_keys.len() > 512 {
+        return Err(AppError::BadRequest(
+            "KV stores are limited to 512 keys per user.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_kv_key(key: &str) -> Result<(), AppError> {
+    if key.is_empty()
+        || key.len() > 255
+        || !key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        return Err(AppError::BadRequest(
+            "KV keys must be alphanumeric and at most 255 characters long.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_kv_value(value: &str) -> Result<(), AppError> {
+    if value.chars().count() > 30_000 {
+        return Err(AppError::BadRequest(
+            "KV values may not exceed 30000 characters.",
+        ));
+    }
+
+    Ok(())
 }
 
 fn is_admin(permissions: Option<Permissions>) -> bool {
@@ -921,6 +1407,51 @@ fn files_command() -> CreateCommand {
         .dm_permission(false)
 }
 
+fn kv_command() -> CreateCommand {
+    CreateCommand::new("kv")
+        .description("Manage your presence KV entries")
+        .add_option(
+            CreateCommandOption::new(
+                CommandOptionType::SubCommand,
+                "get",
+                "Get a KV value or list all keys",
+            )
+            .add_sub_option(
+                CreateCommandOption::new(CommandOptionType::String, "key", "KV key")
+                    .required(false),
+            ),
+        )
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::SubCommand, "set", "Set a KV value")
+                .add_sub_option(
+                    CreateCommandOption::new(CommandOptionType::String, "key", "KV key")
+                        .required(true),
+                )
+                .add_sub_option(
+                    CreateCommandOption::new(CommandOptionType::String, "value", "KV value")
+                        .required(true),
+                ),
+        )
+        .add_option(
+            CreateCommandOption::new(CommandOptionType::SubCommand, "delete", "Delete a KV value")
+                .add_sub_option(
+                    CreateCommandOption::new(CommandOptionType::String, "key", "KV key")
+                        .required(true),
+                ),
+        )
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "clear",
+            "Delete all KV entries",
+        ))
+        .add_option(CreateCommandOption::new(
+            CommandOptionType::SubCommand,
+            "export",
+            "Export all KV entries as JSON",
+        ))
+        .dm_permission(false)
+}
+
 fn admin_users_command() -> CreateCommand {
     CreateCommand::new("admin_users")
         .description("Admin: list users")
@@ -967,4 +1498,108 @@ fn delete_file_command() -> CreateCommand {
         )
         .default_member_permissions(Permissions::ADMINISTRATOR)
         .dm_permission(false)
+}
+
+fn update_disabled(button: CreateButton, disabled: bool) -> CreateButton {
+    button.disabled(disabled)
+}
+
+async fn update_component(
+    ctx: &Context,
+    component: &ComponentInteraction,
+    content: impl Into<String>,
+    components: Vec<CreateActionRow>,
+) -> Result<(), AppError> {
+    component
+        .create_response(
+            &ctx.http,
+            CreateInteractionResponse::UpdateMessage(
+                CreateInteractionResponseMessage::new()
+                    .content(content.into())
+                    .components(components),
+            ),
+        )
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))
+}
+
+fn parse_owned_page_custom_id(custom_id: &str) -> Option<(&str, String, u64)> {
+    let mut parts = custom_id.split(':');
+    let prefix = parts.next()?;
+    let kind = parts.next()?;
+    let owner_id = parts.next()?.to_string();
+    let page = parts.next()?.parse::<u64>().ok()?;
+    if prefix != "page" || parts.next().is_some() {
+        return None;
+    }
+    Some((kind, owner_id, page))
+}
+
+fn clamp_page(page: u64, total_pages: u64) -> u64 {
+    if total_pages == 0 {
+        0
+    } else {
+        page.min(total_pages.saturating_sub(1))
+    }
+}
+
+fn total_pages(total_items: i64, page_size: u64) -> u64 {
+    if total_items <= 0 {
+        0
+    } else {
+        ((total_items as u64) + page_size - 1) / page_size
+    }
+}
+
+fn owned_pagination_components(
+    kind: &str,
+    user_id: u64,
+    current_page: u64,
+    total_pages: u64,
+) -> Vec<CreateActionRow> {
+    if total_pages <= 1 {
+        return Vec::new();
+    }
+
+    vec![CreateActionRow::Buttons(vec![
+        update_disabled(
+            CreateButton::new(format!(
+                "page:{kind}:{user_id}:{}",
+                current_page.saturating_sub(1)
+            ))
+            .label("Previous")
+            .style(ButtonStyle::Secondary),
+            current_page == 0,
+        ),
+        update_disabled(
+            CreateButton::new(format!("page:{kind}:{user_id}:{}", current_page + 1))
+                .label("Next")
+                .style(ButtonStyle::Secondary),
+            current_page + 1 >= total_pages,
+        ),
+    ])]
+}
+
+fn admin_files_pagination_row(current_page: u64, total_pages: u64) -> Option<CreateActionRow> {
+    if total_pages <= 1 {
+        return None;
+    }
+
+    Some(CreateActionRow::Buttons(vec![
+        update_disabled(
+            CreateButton::new(format!(
+                "page:admin_files:{}",
+                current_page.saturating_sub(1)
+            ))
+            .label("Previous")
+            .style(ButtonStyle::Secondary),
+            current_page == 0,
+        ),
+        update_disabled(
+            CreateButton::new(format!("page:admin_files:{}", current_page + 1))
+                .label("Next")
+                .style(ButtonStyle::Secondary),
+            current_page + 1 >= total_pages,
+        ),
+    ]))
 }

--- a/src/discord/mod.rs
+++ b/src/discord/mod.rs
@@ -4,8 +4,9 @@ use serenity::{
     all::{
         ButtonStyle, CommandDataOptionValue, CommandInteraction, CommandOptionType,
         ComponentInteraction, CreateActionRow, CreateButton, CreateCommand, CreateCommandOption,
-        CreateInteractionResponse, CreateInteractionResponseMessage, GatewayIntents, GuildId,
-        Interaction, OnlineStatus, Permissions, Ready,
+        CreateInteractionResponse, CreateInteractionResponseMessage, GatewayIntents, Guild, GuildId,
+        Interaction, Member, OnlineStatus, Permissions, Presence, Ready,
+        User as DiscordUser,
     },
     async_trait,
     client::{Client, Context, EventHandler},
@@ -28,7 +29,8 @@ impl TypeMapKey for ShardManagerContainer {
 }
 
 pub async fn run_bot(state: AppState, token: String, guild_id: u64) -> serenity::Result<()> {
-    let intents = GatewayIntents::GUILDS;
+    let intents =
+        GatewayIntents::GUILDS | GatewayIntents::GUILD_MEMBERS | GatewayIntents::GUILD_PRESENCES;
     let mut client = Client::builder(token, intents)
         .event_handler(Handler {
             state,
@@ -69,6 +71,36 @@ impl EventHandler for Handler {
 
         if let Err(err) = self.guild_id.set_commands(&ctx.http, commands).await {
             tracing::error!("failed to register discord commands: {err}");
+        }
+    }
+
+    async fn guild_create(&self, _ctx: Context, guild: Guild, _is_new: Option<bool>) {
+        if guild.id == self.guild_id {
+            self.state.presence.sync_guild(&guild).await;
+        }
+    }
+
+    async fn guild_member_addition(&self, _ctx: Context, new_member: Member) {
+        if new_member.guild_id == self.guild_id {
+            self.state.presence.upsert_member(&new_member).await;
+        }
+    }
+
+    async fn guild_member_removal(
+        &self,
+        _ctx: Context,
+        guild_id: GuildId,
+        user: DiscordUser,
+        _member_data_if_available: Option<Member>,
+    ) {
+        if guild_id == self.guild_id {
+            self.state.presence.remove_user(user.id.get()).await;
+        }
+    }
+
+    async fn presence_update(&self, _ctx: Context, new_data: Presence) {
+        if new_data.guild_id == Some(self.guild_id) {
+            self.state.presence.update_presence(&new_data).await;
         }
     }
 
@@ -219,6 +251,8 @@ Raw: {}/u/{}.{}",
             .await?;
             return Ok(());
         }
+
+        self.state.presence.upsert_user(&command.user).await;
 
         let discord_id = command.user.id.get().to_string();
         let username = self

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod discord;
 mod error;
 mod models;
+mod presence;
 mod routes;
 mod utils;
 
@@ -17,12 +18,15 @@ use axum::{
     body::Body,
     http::{HeaderValue, StatusCode, header},
     response::Response,
-    routing::{get, post},
+    routing::{get, patch, post, put},
 };
 use config::Config;
 use routes::{
     files::{download_file, raw_file, view_file},
     heartbeat::heartbeat,
+    presence::{
+        delete_presence_kv, get_presence, patch_presence_kv, presence_widget_svg, put_presence_kv,
+    },
     upload::upload_file,
 };
 use sqlx::mysql::MySqlPoolOptions;
@@ -93,6 +97,7 @@ async fn main() {
         config: config.clone(),
         db,
         s3,
+        presence: presence::PresenceService::new(),
     };
 
     if let (Some(token), Some(guild_id)) = (config.discord_token.clone(), config.discord_guild_id) {
@@ -123,6 +128,19 @@ async fn main() {
         )
         .route("/favicon.ico", get(favicon))
         .route("/api/providers/sharex", post(upload_file))
+        .route("/api/discord/{discord_user_id}", get(get_presence))
+        .route(
+            "/api/discord/{discord_user_id}/kv",
+            patch(patch_presence_kv),
+        )
+        .route(
+            "/api/discord/{discord_user_id}/kv/{key}",
+            put(put_presence_kv).delete(delete_presence_kv),
+        )
+        .route(
+            "/api/discord/{discord_user_id}/widget.svg",
+            get(presence_widget_svg),
+        )
         .route("/heartbeat", get(heartbeat))
         .route("/u/{id}", get(raw_file))
         .route("/download/{id}", get(download_file))

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,13 @@ async fn main() {
         .await
         .expect("failed to connect to MySQL");
 
+    tracing::info!("Running database migrations...");
+    sqlx::migrate!("./migrations")
+        .run(&db)
+        .await
+        .expect("failed to run database migrations");
+    tracing::info!("Database migrations complete");
+
     let credentials = Credentials::new(
         config.r2_access_key_id.clone(),
         config.r2_secret_access_key.clone(),

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -25,9 +25,9 @@ impl PresenceService {
             cache
                 .entry(member.user.id.get().to_string())
                 .and_modify(|existing| {
-                    existing.discord_user = DiscordUserSummary::from_user(&member.user);
+                    existing.discord_user = DiscordUserSummary::from_member(member);
                 })
-                .or_insert_with(|| CachedPresence::offline_for_user(&member.user));
+                .or_insert_with(|| CachedPresence::offline_for_member(member));
         }
 
         for presence in guild.presences.values() {
@@ -44,7 +44,15 @@ impl PresenceService {
     }
 
     pub async fn upsert_member(&self, member: &Member) {
-        self.upsert_user(&member.user).await;
+        let mut cache = self.cache.write().await;
+        let key = member.user.id.get().to_string();
+
+        if let Some(existing) = cache.get_mut(&key) {
+            existing.discord_user = DiscordUserSummary::from_member(member);
+            return;
+        }
+
+        cache.insert(key, CachedPresence::offline_for_member(member));
     }
 
     pub async fn upsert_user(&self, user: &User) {
@@ -114,6 +122,21 @@ pub struct CachedPresence {
 
 #[allow(dead_code)]
 impl CachedPresence {
+    pub fn offline_for_member(member: &Member) -> Self {
+        Self {
+            active_on_discord_web: false,
+            active_on_discord_desktop: false,
+            active_on_discord_mobile: false,
+            discord_user: DiscordUserSummary::from_member(member),
+            discord_status: "offline".to_string(),
+            activities: Vec::new(),
+            listening_to_spotify: false,
+            spotify: None,
+            last_updated: Utc::now().timestamp_millis(),
+        }
+    }
+
+
     pub fn from_presence(presence: &Presence) -> Self {
         Self::from_presence_with_existing(presence, None, None)
     }
@@ -233,6 +256,16 @@ pub struct DiscordUserSummary {
 
 #[allow(dead_code)]
 impl DiscordUserSummary {
+    pub fn from_member(member: &Member) -> Self {
+        let mut summary = Self::from_user(&member.user);
+
+        if let Some(nick) = member.nick.as_deref().map(str::trim).filter(|value| !value.is_empty()) {
+            summary.display_name = nick.to_string();
+        }
+
+        summary
+    }
+
     pub fn from_user(user: &User) -> Self {
         Self {
             id: user.id.get().to_string(),
@@ -263,7 +296,23 @@ impl DiscordUserSummary {
         fallback: Option<&DiscordUserSummary>,
     ) -> Self {
         if let Some(full_user) = user.to_user() {
-            return Self::from_user(&full_user);
+            let mut summary = Self::from_user(&full_user);
+
+            if let Some(fallback) = fallback {
+                let fallback_display_name = fallback.display_name.trim();
+                let fallback_username = fallback.username.trim();
+                let fallback_global_name = fallback.global_name.as_deref().map(str::trim);
+                let looks_like_guild_nick = !fallback_display_name.is_empty()
+                    && fallback_display_name != fallback.id
+                    && fallback_display_name != fallback_username
+                    && fallback_global_name != Some(fallback_display_name);
+
+                if looks_like_guild_nick {
+                    summary.display_name = fallback_display_name.to_string();
+                }
+            }
+
+            return summary;
         }
 
         let id = user.id.get().to_string();

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -1,0 +1,610 @@
+use std::{collections::HashMap, sync::Arc};
+
+use chrono::Utc;
+use serde::Serialize;
+use serenity::all::{
+    Activity, ActivityAssets, ActivityEmoji, ActivityTimestamps, ActivityType, Guild, Member,
+    OnlineStatus, Presence, PresenceUser, User,
+};
+use tokio::sync::RwLock;
+
+#[derive(Clone, Default)]
+pub struct PresenceService {
+    cache: Arc<RwLock<HashMap<String, CachedPresence>>>,
+}
+
+impl PresenceService {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn sync_guild(&self, guild: &Guild) {
+        let mut cache = self.cache.write().await;
+
+        for member in guild.members.values() {
+            cache
+                .entry(member.user.id.get().to_string())
+                .and_modify(|existing| {
+                    existing.discord_user = DiscordUserSummary::from_user(&member.user);
+                })
+                .or_insert_with(|| CachedPresence::offline_for_user(&member.user));
+        }
+
+        for presence in guild.presences.values() {
+            let key = presence.user.id.get().to_string();
+            let fallback_user = cache
+                .get(&key)
+                .map(|existing| existing.discord_user.clone());
+
+            cache.insert(
+                key,
+                CachedPresence::from_presence_with_fallback(presence, fallback_user.as_ref()),
+            );
+        }
+    }
+
+    pub async fn upsert_member(&self, member: &Member) {
+        self.upsert_user(&member.user).await;
+    }
+
+    pub async fn upsert_user(&self, user: &User) {
+        let mut cache = self.cache.write().await;
+        let key = user.id.get().to_string();
+
+        if let Some(existing) = cache.get_mut(&key) {
+            existing.discord_user = DiscordUserSummary::from_user(user);
+            return;
+        }
+
+        cache.insert(key, CachedPresence::offline_for_user(user));
+    }
+
+    pub async fn remove_user(&self, user_id: u64) {
+        let mut cache = self.cache.write().await;
+        let key = user_id.to_string();
+
+        if let Some(existing) = cache.get_mut(&key) {
+            existing.active_on_discord_web = false;
+            existing.active_on_discord_desktop = false;
+            existing.active_on_discord_mobile = false;
+            existing.discord_status = "offline".to_string();
+            existing.activities.clear();
+            existing.listening_to_spotify = false;
+            existing.spotify = None;
+            existing.last_updated = Utc::now().timestamp_millis();
+            return;
+        }
+
+        cache.remove(&key);
+    }
+
+    pub async fn update_presence(&self, presence: &Presence) {
+        let mut cache = self.cache.write().await;
+        let key = presence.user.id.get().to_string();
+        let existing = cache.get(&key).cloned();
+        let fallback_user = existing.as_ref().map(|value| value.discord_user.clone());
+
+        cache.insert(
+            key,
+            CachedPresence::from_presence_with_existing(
+                presence,
+                fallback_user.as_ref(),
+                existing.as_ref(),
+            ),
+        );
+    }
+
+    pub async fn get(&self, user_id: &str) -> Option<CachedPresence> {
+        self.cache.read().await.get(user_id).cloned()
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct CachedPresence {
+    pub active_on_discord_web: bool,
+    pub active_on_discord_desktop: bool,
+    pub active_on_discord_mobile: bool,
+    pub discord_user: DiscordUserSummary,
+    pub discord_status: String,
+    pub activities: Vec<ActivitySummary>,
+    pub listening_to_spotify: bool,
+    pub spotify: Option<SpotifySummary>,
+    pub last_updated: i64,
+}
+
+#[allow(dead_code)]
+impl CachedPresence {
+    pub fn from_presence(presence: &Presence) -> Self {
+        Self::from_presence_with_existing(presence, None, None)
+    }
+
+    pub fn from_presence_with_fallback(
+        presence: &Presence,
+        fallback_user: Option<&DiscordUserSummary>,
+    ) -> Self {
+        Self::from_presence_with_existing(presence, fallback_user, None)
+    }
+
+    pub fn from_presence_with_existing(
+        presence: &Presence,
+        fallback_user: Option<&DiscordUserSummary>,
+        existing: Option<&CachedPresence>,
+    ) -> Self {
+        let active_on_discord_web = presence
+            .client_status
+            .as_ref()
+            .map(|status| status.web.is_some())
+            .or_else(|| existing.map(|value| value.active_on_discord_web))
+            .unwrap_or(false);
+        let active_on_discord_desktop = presence
+            .client_status
+            .as_ref()
+            .map(|status| status.desktop.is_some())
+            .or_else(|| existing.map(|value| value.active_on_discord_desktop))
+            .unwrap_or(false);
+        let active_on_discord_mobile = presence
+            .client_status
+            .as_ref()
+            .map(|status| status.mobile.is_some())
+            .or_else(|| existing.map(|value| value.active_on_discord_mobile))
+            .unwrap_or(false);
+
+        let is_offline = matches!(
+            presence.status,
+            OnlineStatus::Offline | OnlineStatus::Invisible
+        );
+        let activities = if is_offline {
+            Vec::new()
+        } else if presence.activities.is_empty() {
+            existing
+                .map(|value| value.activities.clone())
+                .unwrap_or_default()
+        } else {
+            presence
+                .activities
+                .iter()
+                .map(ActivitySummary::from_activity)
+                .collect::<Vec<_>>()
+        };
+        let spotify = if is_offline {
+            None
+        } else {
+            activities
+                .iter()
+                .find(|activity| is_spotify_summary(activity))
+                .map(SpotifySummary::from_summary)
+                .or_else(|| existing.and_then(|value| value.spotify.clone()))
+        };
+
+        Self {
+            active_on_discord_web,
+            active_on_discord_desktop,
+            active_on_discord_mobile,
+            discord_user: DiscordUserSummary::from_presence_user_with_fallback(
+                &presence.user,
+                fallback_user,
+            ),
+            discord_status: online_status_to_string(&presence.status),
+            listening_to_spotify: spotify.is_some(),
+            spotify,
+            activities,
+            last_updated: Utc::now().timestamp_millis(),
+        }
+    }
+
+    pub fn offline_for_user(user: &User) -> Self {
+        Self {
+            active_on_discord_web: false,
+            active_on_discord_desktop: false,
+            active_on_discord_mobile: false,
+            discord_user: DiscordUserSummary::from_user(user),
+            discord_status: "offline".to_string(),
+            activities: Vec::new(),
+            listening_to_spotify: false,
+            spotify: None,
+            last_updated: Utc::now().timestamp_millis(),
+        }
+    }
+
+    pub fn offline_for_registered_user(discord_user_id: &str, username: &str) -> Self {
+        Self {
+            active_on_discord_web: false,
+            active_on_discord_desktop: false,
+            active_on_discord_mobile: false,
+            discord_user: DiscordUserSummary::offline(discord_user_id, username),
+            discord_status: "offline".to_string(),
+            activities: Vec::new(),
+            listening_to_spotify: false,
+            spotify: None,
+            last_updated: Utc::now().timestamp_millis(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct DiscordUserSummary {
+    pub id: String,
+    pub username: String,
+    pub display_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub global_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub discriminator: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar: Option<String>,
+    pub avatar_url: String,
+    pub bot: bool,
+}
+
+#[allow(dead_code)]
+impl DiscordUserSummary {
+    pub fn from_user(user: &User) -> Self {
+        Self {
+            id: user.id.get().to_string(),
+            username: user.name.clone(),
+            display_name: user
+                .global_name
+                .clone()
+                .unwrap_or_else(|| user.name.clone()),
+            global_name: user.global_name.clone(),
+            discriminator: user
+                .discriminator
+                .as_ref()
+                .map(|value| format!("{:04}", value.get())),
+            avatar: user.avatar.as_ref().map(ToString::to_string),
+            avatar_url: user
+                .avatar_url()
+                .unwrap_or_else(|| user.default_avatar_url()),
+            bot: user.bot,
+        }
+    }
+
+    pub fn from_presence_user(user: &PresenceUser) -> Self {
+        Self::from_presence_user_with_fallback(user, None)
+    }
+
+    pub fn from_presence_user_with_fallback(
+        user: &PresenceUser,
+        fallback: Option<&DiscordUserSummary>,
+    ) -> Self {
+        if let Some(full_user) = user.to_user() {
+            return Self::from_user(&full_user);
+        }
+
+        let id = user.id.get().to_string();
+        let username = user
+            .name
+            .clone()
+            .or_else(|| {
+                fallback.and_then(|value| non_empty_non_id(Some(value.username.as_str()), &id))
+            })
+            .unwrap_or_else(|| id.clone());
+        let global_name = user
+            .global_name
+            .clone()
+            .or_else(|| fallback.and_then(|value| non_empty_string(value.global_name.as_deref())));
+        let display_name = global_name
+            .clone()
+            .or_else(|| {
+                fallback.and_then(|value| non_empty_non_id(Some(value.display_name.as_str()), &id))
+            })
+            .unwrap_or_else(|| username.clone());
+        let discriminator = user
+            .discriminator
+            .as_ref()
+            .map(|value| format!("{:04}", value.get()))
+            .or_else(|| fallback.and_then(|value| value.discriminator.clone()));
+        let avatar = user
+            .avatar
+            .as_ref()
+            .map(ToString::to_string)
+            .or_else(|| fallback.and_then(|value| value.avatar.clone()));
+        let avatar_url = avatar
+            .as_deref()
+            .map(|hash| discord_avatar_url(&id, hash))
+            .or_else(|| fallback.map(|value| value.avatar_url.clone()))
+            .unwrap_or_else(|| default_avatar_url(&id, discriminator.as_deref()));
+        let bot = user
+            .bot
+            .unwrap_or_else(|| fallback.map(|value| value.bot).unwrap_or(false));
+
+        Self {
+            id,
+            username,
+            display_name,
+            global_name,
+            discriminator,
+            avatar,
+            avatar_url,
+            bot,
+        }
+    }
+
+    pub fn offline(discord_user_id: &str, username: &str) -> Self {
+        Self {
+            id: discord_user_id.to_string(),
+            username: username.to_string(),
+            display_name: username.to_string(),
+            global_name: None,
+            discriminator: None,
+            avatar: None,
+            avatar_url: default_avatar_url(discord_user_id, None),
+            bot: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ActivitySummary {
+    pub name: String,
+    #[serde(rename = "type")]
+    pub activity_type: u8,
+    #[serde(skip_serializing)]
+    pub kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub application_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub assets: Option<ActivityAssetsSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamps: Option<ActivityTimestampsSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub emoji: Option<ActivityEmojiSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    pub created_at: u64,
+}
+
+impl ActivitySummary {
+    fn from_activity(activity: &Activity) -> Self {
+        Self {
+            name: activity.name.clone(),
+            activity_type: activity_type_to_code(&activity.kind),
+            kind: activity_type_to_string(&activity.kind),
+            state: activity.state.clone(),
+            details: activity.details.clone(),
+            application_id: activity
+                .application_id
+                .as_ref()
+                .map(|id| id.get().to_string()),
+            assets: activity
+                .assets
+                .as_ref()
+                .map(ActivityAssetsSummary::from_assets),
+            timestamps: activity
+                .timestamps
+                .as_ref()
+                .map(ActivityTimestampsSummary::from_timestamps),
+            emoji: activity
+                .emoji
+                .as_ref()
+                .map(ActivityEmojiSummary::from_emoji),
+            url: activity.url.as_ref().map(ToString::to_string),
+            created_at: activity.created_at,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ActivityAssetsSummary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub large_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub large_text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub small_image: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub small_text: Option<String>,
+}
+
+impl ActivityAssetsSummary {
+    fn from_assets(assets: &ActivityAssets) -> Self {
+        Self {
+            large_image: assets.large_image.clone(),
+            large_text: assets.large_text.clone(),
+            small_image: assets.small_image.clone(),
+            small_text: assets.small_text.clone(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ActivityTimestampsSummary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<u64>,
+}
+
+impl ActivityTimestampsSummary {
+    fn from_timestamps(timestamps: &ActivityTimestamps) -> Self {
+        Self {
+            start: timestamps.start,
+            end: timestamps.end,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ActivityEmojiSummary {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub animated: bool,
+}
+
+impl ActivityEmojiSummary {
+    fn from_emoji(emoji: &ActivityEmoji) -> Self {
+        Self {
+            name: emoji.name.clone(),
+            id: emoji.id.as_ref().map(|id| id.get().to_string()),
+            animated: emoji.animated.unwrap_or(false),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct SpotifySummary {
+    pub song: String,
+    pub artist: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub album_art_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamps: Option<ActivityTimestampsSummary>,
+}
+
+#[allow(dead_code)]
+impl SpotifySummary {
+    fn from_activity(activity: &Activity) -> Self {
+        Self::from_summary(&ActivitySummary::from_activity(activity))
+    }
+
+    fn from_summary(activity: &ActivitySummary) -> Self {
+        let album_art_url = activity
+            .assets
+            .as_ref()
+            .and_then(|assets| assets.large_image.as_deref())
+            .and_then(spotify_image_url);
+
+        Self {
+            song: activity
+                .details
+                .clone()
+                .unwrap_or_else(|| activity.name.clone()),
+            artist: activity
+                .state
+                .clone()
+                .unwrap_or_else(|| "Unknown artist".to_string()),
+            album: activity
+                .assets
+                .as_ref()
+                .and_then(|assets| assets.large_text.clone()),
+            album_art_url,
+            timestamps: activity.timestamps.clone(),
+        }
+    }
+}
+
+fn spotify_image_url(value: &str) -> Option<String> {
+    value
+        .strip_prefix("spotify:")
+        .map(|hash| format!("https://i.scdn.co/image/{hash}"))
+        .or_else(|| {
+            if value.starts_with("https://") || value.starts_with("http://") {
+                Some(value.to_string())
+            } else {
+                None
+            }
+        })
+}
+
+#[allow(dead_code)]
+fn is_spotify_activity(activity: &Activity) -> bool {
+    if !matches!(activity.kind, ActivityType::Listening) {
+        return false;
+    }
+
+    if activity.name.eq_ignore_ascii_case("Spotify") {
+        return true;
+    }
+
+    activity
+        .assets
+        .as_ref()
+        .and_then(|assets| assets.large_image.as_deref())
+        .map(|value| value.starts_with("spotify:"))
+        .unwrap_or(false)
+}
+
+fn is_spotify_summary(activity: &ActivitySummary) -> bool {
+    if activity.kind != "listening" {
+        return false;
+    }
+
+    if activity.name.eq_ignore_ascii_case("Spotify") {
+        return true;
+    }
+
+    activity
+        .assets
+        .as_ref()
+        .and_then(|assets| assets.large_image.as_deref())
+        .map(|value| value.starts_with("spotify:"))
+        .unwrap_or(false)
+}
+
+fn online_status_to_string(status: &OnlineStatus) -> String {
+    match status {
+        OnlineStatus::Online => "online",
+        OnlineStatus::Idle => "idle",
+        OnlineStatus::DoNotDisturb => "dnd",
+        OnlineStatus::Invisible => "offline",
+        OnlineStatus::Offline => "offline",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn activity_type_to_code(kind: &ActivityType) -> u8 {
+    match kind {
+        ActivityType::Playing => 0,
+        ActivityType::Streaming => 1,
+        ActivityType::Listening => 2,
+        ActivityType::Watching => 3,
+        ActivityType::Custom => 4,
+        ActivityType::Competing => 5,
+        ActivityType::Unknown(value) => *value,
+        _ => 255,
+    }
+}
+
+fn activity_type_to_string(kind: &ActivityType) -> String {
+    match kind {
+        ActivityType::Playing => "playing",
+        ActivityType::Streaming => "streaming",
+        ActivityType::Listening => "listening",
+        ActivityType::Watching => "watching",
+        ActivityType::Custom => "custom",
+        ActivityType::Competing => "competing",
+        _ => "unknown",
+    }
+    .to_string()
+}
+
+fn discord_avatar_url(user_id: &str, hash: &str) -> String {
+    let extension = if hash.starts_with("a_") { "gif" } else { "png" };
+    format!("https://cdn.discordapp.com/avatars/{user_id}/{hash}.{extension}?size=256")
+}
+
+fn default_avatar_url(user_id: &str, discriminator: Option<&str>) -> String {
+    let index = discriminator
+        .and_then(|value| value.parse::<u64>().ok())
+        .map(|value| value % 5)
+        .unwrap_or_else(|| {
+            user_id
+                .parse::<u64>()
+                .map(|value| (value >> 22) % 6)
+                .unwrap_or(0)
+        });
+
+    format!("https://cdn.discordapp.com/embed/avatars/{index}.png")
+}
+
+fn non_empty_string(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| value.to_string())
+}
+
+fn non_empty_non_id(value: Option<&str>, user_id: &str) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty() && *value != user_id)
+        .map(|value| value.to_string())
+}

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -153,29 +153,22 @@ impl CachedPresence {
             presence.status,
             OnlineStatus::Offline | OnlineStatus::Invisible
         );
-        let has_fresh_activities = !presence.activities.is_empty();
         let activities = if is_offline {
             Vec::new()
-        } else if has_fresh_activities {
+        } else {
             presence
                 .activities
                 .iter()
                 .map(ActivitySummary::from_activity)
                 .collect::<Vec<_>>()
-        } else {
-            existing
-                .map(|value| value.activities.clone())
-                .unwrap_or_default()
         };
         let spotify = if is_offline {
             None
-        } else if has_fresh_activities {
+        } else {
             activities
                 .iter()
                 .find(|activity| is_spotify_summary(activity))
                 .map(SpotifySummary::from_summary)
-        } else {
-            existing.and_then(|value| value.spotify.clone())
         };
 
         Self {

--- a/src/presence.rs
+++ b/src/presence.rs
@@ -153,27 +153,29 @@ impl CachedPresence {
             presence.status,
             OnlineStatus::Offline | OnlineStatus::Invisible
         );
+        let has_fresh_activities = !presence.activities.is_empty();
         let activities = if is_offline {
             Vec::new()
-        } else if presence.activities.is_empty() {
-            existing
-                .map(|value| value.activities.clone())
-                .unwrap_or_default()
-        } else {
+        } else if has_fresh_activities {
             presence
                 .activities
                 .iter()
                 .map(ActivitySummary::from_activity)
                 .collect::<Vec<_>>()
+        } else {
+            existing
+                .map(|value| value.activities.clone())
+                .unwrap_or_default()
         };
         let spotify = if is_offline {
             None
-        } else {
+        } else if has_fresh_activities {
             activities
                 .iter()
                 .find(|activity| is_spotify_summary(activity))
                 .map(SpotifySummary::from_summary)
-                .or_else(|| existing.and_then(|value| value.spotify.clone()))
+        } else {
+            existing.and_then(|value| value.spotify.clone())
         };
 
         Self {
@@ -490,7 +492,7 @@ impl SpotifySummary {
     }
 }
 
-fn spotify_image_url(value: &str) -> Option<String> {
+pub fn spotify_image_url(value: &str) -> Option<String> {
     value
         .strip_prefix("spotify:")
         .map(|hash| format!("https://i.scdn.co/image/{hash}"))

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,4 @@
-pub mod heartbeat;
 pub mod files;
+pub mod heartbeat;
+pub mod presence;
 pub mod upload;

--- a/src/routes/presence.rs
+++ b/src/routes/presence.rs
@@ -582,7 +582,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
     };
 
     format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" width="380" height="210" viewBox="0 0 380 210" role="img" aria-labelledby="title desc">
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="430" height="210" viewBox="0 0 430 210" role="img" aria-labelledby="title desc">
   <title id="title">Discord presence for {display_name}</title>
   <desc id="desc">{desc}</desc>
 
@@ -598,7 +598,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
     </clipPath>
   </defs>
 
-  <rect x="1" y="1" width="378" height="208" rx="14" fill="{background}" stroke="{border}" />
+  <rect x="1" y="1" width="428" height="208" rx="14" fill="{background}" stroke="{border}" />
 
   <rect x="18" y="18" width="54" height="54" rx="14" fill="{panel_soft}" stroke="{border}" />
   <image
@@ -617,7 +617,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
   <text x="86" y="40" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">{display_name}</text>
   <text x="86" y="60" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12.5" font-weight="500">{username}</text>
 {custom_status_svg}
-  <line x1="6" y1="95" x2="374" y2="95" stroke="{border}" stroke-width="1" />
+  <line x1="6" y1="95" x2="424" y2="95" stroke="{border}" stroke-width="1" />
 
 {activity_asset_markup}{activity_small_asset_markup}  <text x="{text_x}" y="{activity_label_y}" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.4px">{activity_name}</text>
   <text x="{text_x}" y="{activity_title_y}" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14.5" font-weight="700">{activity}</text>

--- a/src/routes/presence.rs
+++ b/src/routes/presence.rs
@@ -1,0 +1,708 @@
+use std::collections::{HashMap, HashSet};
+
+use axum::{
+    Json,
+    body::Bytes,
+    extract::{Path, Query, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::FromRow;
+
+use crate::{
+    app_state::AppState,
+    error::AppError,
+    models::User,
+    presence::{ActivitySummary, CachedPresence, DiscordUserSummary},
+    utils::{
+        html::{escape_attr, escape_html},
+        ids::is_valid_hex_colour,
+    },
+};
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PresenceEnvelope {
+    pub success: bool,
+    pub data: PresencePayload,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PresencePayload {
+    #[serde(flatten)]
+    pub presence: CachedPresence,
+    pub kv: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, FromRow)]
+struct KvRow {
+    kv_key: String,
+    kv_value: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct WidgetQuery {
+    pub theme: Option<String>,
+    pub accent: Option<String>,
+    pub idle_message: Option<String>,
+}
+
+pub async fn get_presence(
+    State(state): State<AppState>,
+    Path(discord_user_id): Path<String>,
+) -> Result<(StatusCode, HeaderMap, Json<PresenceEnvelope>), AppError> {
+    let payload = load_presence_payload(&state, &discord_user_id).await?;
+
+    Ok(json_response(
+        StatusCode::OK,
+        PresenceEnvelope {
+            success: true,
+            data: payload,
+        },
+    ))
+}
+
+pub async fn put_presence_kv(
+    State(state): State<AppState>,
+    Path((discord_user_id, key)): Path<(String, String)>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<(StatusCode, HeaderMap, Json<PresenceEnvelope>), AppError> {
+    validate_kv_key(&key)?;
+    let value = String::from_utf8_lossy(&body).to_string();
+    validate_kv_value(&value)?;
+
+    let user = authorised_kv_user(&state, &headers, &discord_user_id).await?;
+    ensure_kv_capacity(&state, user.id, &[key.clone()]).await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO user_presence_kv (user_id, kv_key, kv_value)
+        VALUES (?, ?, ?)
+        ON DUPLICATE KEY UPDATE kv_value = VALUES(kv_value), updated_at = UTC_TIMESTAMP()
+        "#,
+    )
+    .bind(user.id)
+    .bind(&key)
+    .bind(&value)
+    .execute(&state.db)
+    .await?;
+
+    let payload = load_presence_payload(&state, &discord_user_id).await?;
+
+    Ok(json_response(
+        StatusCode::OK,
+        PresenceEnvelope {
+            success: true,
+            data: payload,
+        },
+    ))
+}
+
+pub async fn patch_presence_kv(
+    State(state): State<AppState>,
+    Path(discord_user_id): Path<String>,
+    headers: HeaderMap,
+    Json(body): Json<HashMap<String, Value>>,
+) -> Result<(StatusCode, HeaderMap, Json<PresenceEnvelope>), AppError> {
+    let user = authorised_kv_user(&state, &headers, &discord_user_id).await?;
+
+    let mut items = Vec::with_capacity(body.len());
+    for (key, value) in body {
+        validate_kv_key(&key)?;
+        let value = scalar_json_to_string(value)?;
+        validate_kv_value(&value)?;
+        items.push((key, value));
+    }
+
+    let keys = items.iter().map(|(key, _)| key.clone()).collect::<Vec<_>>();
+    ensure_kv_capacity(&state, user.id, &keys).await?;
+
+    for (key, value) in items {
+        sqlx::query(
+            r#"
+            INSERT INTO user_presence_kv (user_id, kv_key, kv_value)
+            VALUES (?, ?, ?)
+            ON DUPLICATE KEY UPDATE kv_value = VALUES(kv_value), updated_at = UTC_TIMESTAMP()
+            "#,
+        )
+        .bind(user.id)
+        .bind(&key)
+        .bind(&value)
+        .execute(&state.db)
+        .await?;
+    }
+
+    let payload = load_presence_payload(&state, &discord_user_id).await?;
+
+    Ok(json_response(
+        StatusCode::OK,
+        PresenceEnvelope {
+            success: true,
+            data: payload,
+        },
+    ))
+}
+
+pub async fn delete_presence_kv(
+    State(state): State<AppState>,
+    Path((discord_user_id, key)): Path<(String, String)>,
+    headers: HeaderMap,
+) -> Result<(StatusCode, HeaderMap, Json<PresenceEnvelope>), AppError> {
+    validate_kv_key(&key)?;
+    let user = authorised_kv_user(&state, &headers, &discord_user_id).await?;
+
+    sqlx::query("DELETE FROM user_presence_kv WHERE user_id = ? AND kv_key = ?")
+        .bind(user.id)
+        .bind(&key)
+        .execute(&state.db)
+        .await?;
+
+    let payload = load_presence_payload(&state, &discord_user_id).await?;
+
+    Ok(json_response(
+        StatusCode::OK,
+        PresenceEnvelope {
+            success: true,
+            data: payload,
+        },
+    ))
+}
+
+pub async fn presence_widget_svg(
+    State(state): State<AppState>,
+    Path(discord_user_id): Path<String>,
+    Query(query): Query<WidgetQuery>,
+) -> Result<(StatusCode, HeaderMap, String), AppError> {
+    let payload = load_presence_payload(&state, &discord_user_id).await?;
+    let svg = render_widget_svg(&payload, &query);
+
+    Ok(svg_response(svg))
+}
+
+async fn load_presence_payload(
+    state: &AppState,
+    discord_user_id: &str,
+) -> Result<PresencePayload, AppError> {
+    let registered_user = registered_user_by_discord_id(state, discord_user_id).await?;
+    let kv = if let Some(user) = registered_user.as_ref() {
+        load_kv_for_user(state, user.id).await?
+    } else {
+        HashMap::new()
+    };
+
+    let mut presence = match (
+        state.presence.get(discord_user_id).await,
+        registered_user.as_ref(),
+    ) {
+        (Some(presence), _) => presence,
+        (None, Some(user)) => {
+            CachedPresence::offline_for_registered_user(discord_user_id, &user.username)
+        }
+        (None, None) => return Err(AppError::NotFound("Discord presence not found.")),
+    };
+
+    if presence.discord_user.username.trim().is_empty()
+        || presence.discord_user.username == presence.discord_user.id
+    {
+        if let Some(user) = registered_user.as_ref() {
+            presence.discord_user.username = user.username.clone();
+        }
+    }
+
+    if (presence.discord_user.display_name.trim().is_empty()
+        || presence.discord_user.display_name == presence.discord_user.id)
+        && !presence.discord_user.username.trim().is_empty()
+        && presence.discord_user.username != presence.discord_user.id
+    {
+        presence.discord_user.display_name = presence.discord_user.username.clone();
+    }
+
+    Ok(PresencePayload { presence, kv })
+}
+
+async fn registered_user_by_discord_id(
+    state: &AppState,
+    discord_user_id: &str,
+) -> Result<Option<User>, AppError> {
+    sqlx::query_as::<_, User>(
+        r#"
+        SELECT id, username, api_token, discord_user_id, preferred_url_mode, preferred_hex_colour, is_blacklisted, created_at
+        FROM users
+        WHERE discord_user_id = ?
+        LIMIT 1
+        "#,
+    )
+    .bind(discord_user_id)
+    .fetch_optional(&state.db)
+    .await
+    .map_err(Into::into)
+}
+
+async fn load_kv_for_user(
+    state: &AppState,
+    user_id: u64,
+) -> Result<HashMap<String, String>, AppError> {
+    let rows = sqlx::query_as::<_, KvRow>(
+        r#"
+        SELECT kv_key, kv_value
+        FROM user_presence_kv
+        WHERE user_id = ?
+        ORDER BY kv_key ASC
+        "#,
+    )
+    .bind(user_id)
+    .fetch_all(&state.db)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.kv_key, row.kv_value))
+        .collect())
+}
+
+async fn authorised_kv_user(
+    state: &AppState,
+    headers: &HeaderMap,
+    discord_user_id: &str,
+) -> Result<User, AppError> {
+    let auth = headers
+        .get("Authorisation")
+        .or_else(|| headers.get("Authorization"))
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or(AppError::Unauthorized(
+            "You are not authorised to use this endpoint.",
+        ))?;
+
+    let user: Option<User> = sqlx::query_as::<_, User>(
+        r#"
+        SELECT id, username, api_token, discord_user_id, preferred_url_mode, preferred_hex_colour, is_blacklisted, created_at
+        FROM users
+        WHERE api_token = ?
+        LIMIT 1
+        "#,
+    )
+    .bind(auth)
+    .fetch_optional(&state.db)
+    .await?;
+
+    let user = user.ok_or(AppError::Unauthorized(
+        "You are not authorised to use this endpoint.",
+    ))?;
+
+    if user.is_blacklisted {
+        return Err(AppError::Unauthorized(
+            "Your account is blacklisted from using the API.",
+        ));
+    }
+
+    if user.discord_user_id.as_deref() != Some(discord_user_id) {
+        return Err(AppError::Unauthorized(
+            "This API token does not belong to that Discord user.",
+        ));
+    }
+
+    Ok(user)
+}
+
+async fn ensure_kv_capacity(
+    state: &AppState,
+    user_id: u64,
+    candidate_keys: &[String],
+) -> Result<(), AppError> {
+    let existing_keys =
+        sqlx::query_as::<_, (String,)>("SELECT kv_key FROM user_presence_kv WHERE user_id = ?")
+            .bind(user_id)
+            .fetch_all(&state.db)
+            .await?;
+
+    let mut all_keys = existing_keys
+        .into_iter()
+        .map(|(key,)| key)
+        .collect::<HashSet<_>>();
+
+    for key in candidate_keys {
+        all_keys.insert(key.clone());
+    }
+
+    if all_keys.len() > 512 {
+        return Err(AppError::BadRequest(
+            "KV stores are limited to 512 keys per user.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_kv_key(key: &str) -> Result<(), AppError> {
+    if key.is_empty()
+        || key.len() > 255
+        || !key
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        return Err(AppError::BadRequest(
+            "KV keys must be alphanumeric and at most 255 characters long.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn validate_kv_value(value: &str) -> Result<(), AppError> {
+    if value.chars().count() > 30_000 {
+        return Err(AppError::BadRequest(
+            "KV values may not exceed 30000 characters.",
+        ));
+    }
+
+    Ok(())
+}
+
+fn scalar_json_to_string(value: Value) -> Result<String, AppError> {
+    match value {
+        Value::String(value) => Ok(value),
+        Value::Number(value) => Ok(value.to_string()),
+        Value::Bool(value) => Ok(value.to_string()),
+        Value::Null => Ok("null".to_string()),
+        Value::Array(_) | Value::Object(_) => Err(AppError::BadRequest(
+            "KV patch values must be strings, numbers, booleans, or null.",
+        )),
+    }
+}
+
+fn json_response<T: Serialize>(status: StatusCode, value: T) -> (StatusCode, HeaderMap, Json<T>) {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, max-age=0"),
+    );
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+
+    (status, headers, Json(value))
+}
+
+fn svg_response(svg: String) -> (StatusCode, HeaderMap, String) {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("image/svg+xml; charset=utf-8"),
+    );
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store, max-age=0"),
+    );
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+
+    (StatusCode::OK, headers, svg)
+}
+
+fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
+    let palette = palette(query.theme.as_deref());
+    let background = query
+        .accent
+        .as_deref()
+        .filter(|value| is_valid_hex_colour(value))
+        .unwrap_or(palette.bg);
+
+    let status_accent = status_colour(&payload.presence.discord_status);
+
+    let username = truncate(
+        non_empty(Some(payload.presence.discord_user.username.as_str()))
+            .unwrap_or(payload.presence.discord_user.id.as_str()),
+        28,
+    );
+    let display_name = truncate(&preferred_display_name(&payload.presence.discord_user), 28);
+
+    let activity_line = truncate(
+        &primary_activity_line(payload, query.idle_message.as_deref()),
+        48,
+    );
+
+    let footer_line = truncate(&secondary_activity_line(payload, ""), 56);
+
+    let avatar_url = discord_avatar_url(&payload.presence.discord_user);
+    let escaped_avatar_url = escape_attr(&avatar_url);
+    let escaped_username = escape_html(&username);
+    let escaped_display_name = escape_html(&display_name);
+    let escaped_activity = escape_html(&activity_line);
+    let escaped_footer = escape_html(&footer_line);
+    let escaped_desc = escape_attr(&activity_line);
+
+    format!(
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="420" height="160" viewBox="0 0 420 160" role="img" aria-labelledby="title desc">
+  <title id="title">Discord presence for {display_name}</title>
+  <desc id="desc">{desc}</desc>
+
+  <defs>
+    <clipPath id="avatarClip">
+      <rect x="20" y="20" width="64" height="64" rx="12" />
+    </clipPath>
+  </defs>
+
+  <rect x="1" y="1" width="418" height="158" rx="12" fill="{background}" stroke="{border}" />
+
+  <rect x="20" y="20" width="64" height="64" rx="12" fill="{panel_soft}" stroke="{border}" />
+  <image
+    href="{avatar_url}"
+    x="20"
+    y="20"
+    width="64"
+    height="64"
+    preserveAspectRatio="xMidYMid slice"
+    clip-path="url(#avatarClip)"
+  />
+
+  <circle cx="78" cy="78" r="9" fill="{background}" />
+  <circle cx="78" cy="78" r="6" fill="{status_accent}" stroke="{panel}" stroke-width="1.5" />
+
+  <text x="100" y="36" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="600">@{username}</text>
+  <text x="100" y="58" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">{display_name}</text>
+
+  <!-- pushed HR down -->
+  <line x1="20" y1="110" x2="400" y2="110" stroke="{border}" stroke-width="1" />
+
+  <!-- more breathing room -->
+  <text x="20" y="132" fill="{body}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14">{activity}</text>
+  <text x="20" y="148" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11">{footer}</text>
+</svg>"#,
+        display_name = escaped_display_name,
+        desc = escaped_desc,
+        background = background,
+        border = palette.border,
+        panel = palette.panel,
+        panel_soft = palette.panel_soft,
+        avatar_url = escaped_avatar_url,
+        status_accent = status_accent,
+        username = escaped_username,
+        title_color = palette.title,
+        muted = palette.muted,
+        body = palette.body,
+        activity = escaped_activity,
+        footer = escaped_footer,
+    )
+}
+
+fn discord_avatar_url(user: &DiscordUserSummary) -> String {
+    if let Some(avatar) = non_empty(user.avatar.as_deref()) {
+        let ext = if avatar.starts_with("a_") {
+            "gif"
+        } else {
+            "png"
+        };
+        return format!(
+            "https://cdn.discordapp.com/avatars/{}/{}.{}?size=128",
+            user.id, avatar, ext
+        );
+    }
+
+    let discriminator_mod = user.id.parse::<u64>().map(|id| (id >> 22) % 6).unwrap_or(0);
+
+    format!(
+        "https://cdn.discordapp.com/embed/avatars/{}.png",
+        discriminator_mod
+    )
+}
+
+fn primary_activity_line(payload: &PresencePayload, idle_message: Option<&str>) -> String {
+    if let Some(spotify) = payload.presence.spotify.as_ref() {
+        return format!("Listening to {}", spotify.song);
+    }
+
+    if let Some(activity) = rich_activity(payload) {
+        return format_primary_activity(activity);
+    }
+
+    if let Some(custom) = custom_status_text(payload) {
+        return custom;
+    }
+
+    idle_message
+        .unwrap_or("No current Discord activity")
+        .to_string()
+}
+
+fn secondary_activity_line(payload: &PresencePayload, status_line: &str) -> String {
+    if let Some(spotify) = payload.presence.spotify.as_ref() {
+        return match spotify.album.as_deref() {
+            Some(album) if !album.trim().is_empty() => {
+                format!("{} • {}", spotify.artist, album)
+            }
+            _ => spotify.artist.clone(),
+        };
+    }
+
+    if let Some(activity) = rich_activity(payload) {
+        if let Some(context) = activity_context_line(activity) {
+            return context;
+        }
+
+        if let Some(custom) = custom_status_text(payload) {
+            return custom;
+        }
+
+        return format!(
+            "{} • {}",
+            pretty_activity_kind(&activity.kind),
+            activity.name
+        );
+    }
+
+    if let Some(custom) = custom_status_text(payload) {
+        return custom;
+    }
+
+    if payload.kv.is_empty() {
+        status_line.to_string()
+    } else {
+        format!(
+            "{} • {} KV entr{}",
+            status_line,
+            payload.kv.len(),
+            if payload.kv.len() == 1 { "y" } else { "ies" }
+        )
+    }
+}
+
+fn rich_activity(payload: &PresencePayload) -> Option<&ActivitySummary> {
+    payload
+        .presence
+        .activities
+        .iter()
+        .find(|activity| activity.kind != "custom")
+}
+
+fn custom_status_text(payload: &PresencePayload) -> Option<String> {
+    let custom = payload
+        .presence
+        .activities
+        .iter()
+        .find(|activity| activity.kind == "custom")?;
+
+    let emoji = custom
+        .emoji
+        .as_ref()
+        .and_then(|value| non_empty(Some(value.name.as_str())));
+    let state = non_empty(custom.state.as_deref());
+
+    match (emoji, state) {
+        (Some(emoji), Some(state)) => Some(format!("{} {}", emoji, state)),
+        (Some(emoji), None) => Some(emoji.to_string()),
+        (None, Some(state)) => Some(state.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn format_primary_activity(activity: &ActivitySummary) -> String {
+    if let Some(name) = non_empty(Some(activity.name.as_str())) {
+        return match activity.kind.as_str() {
+            "playing" => format!("Playing {}", name),
+            "streaming" => format!("Streaming {}", name),
+            "listening" => format!("Listening to {}", name),
+            "watching" => format!("Watching {}", name),
+            "competing" => format!("Competing in {}", name),
+            _ => name.to_string(),
+        };
+    }
+
+    non_empty(activity.details.as_deref())
+        .or_else(|| non_empty(activity.state.as_deref()))
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| pretty_activity_kind(&activity.kind).to_string())
+}
+
+fn activity_context_line(activity: &ActivitySummary) -> Option<String> {
+    match (
+        non_empty(activity.details.as_deref()),
+        non_empty(activity.state.as_deref()),
+    ) {
+        (Some(details), Some(state)) => Some(format!("{} • {}", details, state)),
+        (Some(details), None) => Some(details.to_string()),
+        (None, Some(state)) => Some(state.to_string()),
+        (None, None) => None,
+    }
+}
+
+fn preferred_display_name(user: &DiscordUserSummary) -> String {
+    non_empty(Some(user.display_name.as_str()))
+        .filter(|value| *value != user.id.as_str())
+        .or_else(|| {
+            non_empty(Some(user.username.as_str())).filter(|value| *value != user.id.as_str())
+        })
+        .unwrap_or(user.id.as_str())
+        .to_string()
+}
+
+fn non_empty<'a>(value: Option<&'a str>) -> Option<&'a str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn pretty_activity_kind(kind: &str) -> &'static str {
+    match kind {
+        "playing" => "Playing",
+        "streaming" => "Streaming",
+        "listening" => "Listening",
+        "watching" => "Watching",
+        "competing" => "Competing",
+        "custom" => "Custom status",
+        _ => "Activity",
+    }
+}
+
+fn truncate(value: &str, max_chars: usize) -> String {
+    let char_count = value.chars().count();
+    if char_count <= max_chars {
+        return value.to_string();
+    }
+
+    let truncated = value
+        .chars()
+        .take(max_chars.saturating_sub(1))
+        .collect::<String>();
+    format!("{}…", truncated)
+}
+
+fn status_colour(status: &str) -> &'static str {
+    match status {
+        "online" => "#22c55e",
+        "idle" => "#f59e0b",
+        "dnd" => "#ef4444",
+        "offline" => "#64748b",
+        _ => "#7c3aed",
+    }
+}
+
+struct Palette {
+    bg: &'static str,
+    panel: &'static str,
+    panel_soft: &'static str,
+    border: &'static str,
+    title: &'static str,
+    body: &'static str,
+    muted: &'static str,
+}
+
+fn palette(theme: Option<&str>) -> Palette {
+    match theme.unwrap_or("dark").to_ascii_lowercase().as_str() {
+        "light" => Palette {
+            bg: "#eef2ff",
+            panel: "#ffffff",
+            panel_soft: "#f8fafc",
+            border: "#dbe4f0",
+            title: "#0f172a",
+            body: "#1e293b",
+            muted: "#475569",
+        },
+        _ => Palette {
+            bg: "#0f1117",
+            panel: "#181c25",
+            panel_soft: "#10141c",
+            border: "#2b3444",
+            title: "#f8fafc",
+            body: "#e2e8f0",
+            muted: "#94a3b8",
+        },
+    }
+}

--- a/src/routes/presence.rs
+++ b/src/routes/presence.rs
@@ -1,4 +1,5 @@
 use std::collections::{HashMap, HashSet};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use axum::{
     Json,
@@ -14,7 +15,7 @@ use crate::{
     app_state::AppState,
     error::AppError,
     models::User,
-    presence::{ActivitySummary, CachedPresence, DiscordUserSummary},
+    presence::{ActivitySummary, CachedPresence, DiscordUserSummary, spotify_image_url},
     utils::{
         html::{escape_attr, escape_html},
         ids::is_valid_hex_colour,
@@ -409,79 +410,237 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
 
     let status_accent = status_colour(&payload.presence.discord_status);
 
-    let username = truncate(
+    let raw_username = truncate(
         non_empty(Some(payload.presence.discord_user.username.as_str()))
             .unwrap_or(payload.presence.discord_user.id.as_str()),
-        28,
+        24,
     );
-    let display_name = truncate(&preferred_display_name(&payload.presence.discord_user), 28);
+    let username = if raw_username.starts_with('@') {
+        raw_username
+    } else {
+        format!("@{}", raw_username)
+    };
+
+    let display_name = truncate(&preferred_display_name(&payload.presence.discord_user), 24);
 
     let activity_line = truncate(
         &primary_activity_line(payload, query.idle_message.as_deref()),
-        48,
+        28,
     );
 
-    let footer_line = truncate(&secondary_activity_line(payload, ""), 56);
+    let secondary_lines = secondary_activity_lines(payload, "")
+        .into_iter()
+        .map(|line| truncate(&line, 30))
+        .collect::<Vec<_>>();
+
+    let elapsed_line = elapsed_activity_line(payload)
+        .map(|value| truncate(&value, 34))
+        .unwrap_or_default();
 
     let avatar_url = discord_avatar_url(&payload.presence.discord_user);
+    let activity_asset_url = widget_activity_asset_url(payload);
+    let activity_small_asset_url = widget_activity_small_asset_url(payload);
+
+    let activity_name = truncate(&widget_activity_name(payload), 24);
+
     let escaped_avatar_url = escape_attr(&avatar_url);
     let escaped_username = escape_html(&username);
     let escaped_display_name = escape_html(&display_name);
     let escaped_activity = escape_html(&activity_line);
-    let escaped_footer = escape_html(&footer_line);
     let escaped_desc = escape_attr(&activity_line);
+    let escaped_activity_name = escape_html(&activity_name.to_uppercase());
+
+    let activity_label_y = 126;
+    let activity_title_y = 146;
+    let secondary_start_y = 162;
+    let secondary_gap = 14;
+    let elapsed_y = if !elapsed_line.is_empty() {
+        secondary_start_y + (secondary_lines.len() as i32 * secondary_gap) + 4
+    } else if secondary_lines.is_empty() {
+        activity_title_y
+    } else {
+        secondary_start_y + ((secondary_lines.len() as i32 - 1) * secondary_gap)
+    };
+
+    let activity_asset_x = 18;
+    let activity_asset_y = 112;
+    let activity_asset_min_size = 65;
+    let activity_asset_size = if activity_asset_url.is_some() {
+        (elapsed_y - activity_asset_y + 4).max(activity_asset_min_size)
+    } else {
+        activity_asset_min_size
+    };
+    let activity_asset_radius = 14;
+
+    let small_asset_size = 24;
+    let small_asset_x = activity_asset_x + activity_asset_size - small_asset_size + 4;
+    let small_asset_y = activity_asset_y + activity_asset_size - small_asset_size + 4;
+    let small_asset_radius = 12;
+
+    let activity_asset_markup = activity_asset_url
+        .as_deref()
+        .map(|url| {
+            format!(
+                r#"  <rect x="{x}" y="{y}" width="{size}" height="{size}" rx="{radius}" fill="{panel_soft}" stroke="{border}" />
+  <image
+    href="{asset_url}"
+    x="{x}"
+    y="{y}"
+    width="{size}"
+    height="{size}"
+    preserveAspectRatio="xMidYMid slice"
+    clip-path="url(#activityAssetClip)"
+  />
+"#,
+                x = activity_asset_x,
+                y = activity_asset_y,
+                size = activity_asset_size,
+                radius = activity_asset_radius,
+                panel_soft = palette.panel_soft,
+                border = palette.border,
+                asset_url = escape_attr(url),
+            )
+        })
+        .unwrap_or_default();
+
+    let activity_small_asset_markup = if activity_asset_url.is_some()
+        && activity_small_asset_url.is_some()
+    {
+        activity_small_asset_url
+                .as_deref()
+                .map(|url| {
+                    format!(
+                        r#"
+  <rect x="{x}" y="{y}" width="{size}" height="{size}" rx="{radius}" fill="{panel}" stroke="{border}" stroke-width="1.5" />
+  <image
+    href="{asset_url}"
+    x="{x}"
+    y="{y}"
+    width="{size}"
+    height="{size}"
+    preserveAspectRatio="xMidYMid slice"
+    clip-path="url(#activitySmallAssetClip)"
+  />
+"#,
+                        x = small_asset_x,
+                        y = small_asset_y,
+                        size = small_asset_size,
+                        radius = small_asset_radius,
+                        panel = palette.panel,
+                        border = palette.border,
+                        asset_url = escape_attr(url),
+                    )
+                })
+                .unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    let text_x = if activity_asset_url.is_some() {
+        activity_asset_x + activity_asset_size + 16
+    } else {
+        18
+    };
+
+    let secondary_svg = secondary_lines
+        .iter()
+        .enumerate()
+        .map(|(index, line)| {
+            let y = secondary_start_y + (index as i32 * secondary_gap);
+            format!(
+                r#"  <text x="{x}" y="{y}" fill="{body}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11.5">{line}</text>"#,
+                x = text_x,
+                y = y,
+                body = palette.body,
+                line = escape_html(line),
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let elapsed_svg = if !elapsed_line.is_empty() {
+        format!(
+            r#"  <text x="{x}" y="{y}" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11.5">{elapsed}</text>"#,
+            x = text_x,
+            y = elapsed_y,
+            muted = palette.muted,
+            elapsed = escape_html(&elapsed_line),
+        )
+    } else {
+        String::new()
+    };
 
     format!(
-        r#"<svg xmlns="http://www.w3.org/2000/svg" width="420" height="160" viewBox="0 0 420 160" role="img" aria-labelledby="title desc">
+        r#"<svg xmlns="http://www.w3.org/2000/svg" width="380" height="210" viewBox="0 0 380 210" role="img" aria-labelledby="title desc">
   <title id="title">Discord presence for {display_name}</title>
   <desc id="desc">{desc}</desc>
 
   <defs>
     <clipPath id="avatarClip">
-      <rect x="20" y="20" width="64" height="64" rx="12" />
+      <rect x="18" y="18" width="54" height="54" rx="14" />
+    </clipPath>
+    <clipPath id="activityAssetClip">
+      <rect x="{activity_asset_x}" y="{activity_asset_y}" width="{activity_asset_size}" height="{activity_asset_size}" rx="{activity_asset_radius}" />
+    </clipPath>
+    <clipPath id="activitySmallAssetClip">
+      <rect x="{small_asset_x}" y="{small_asset_y}" width="{small_asset_size}" height="{small_asset_size}" rx="{small_asset_radius}" />
     </clipPath>
   </defs>
 
-  <rect x="1" y="1" width="418" height="158" rx="12" fill="{background}" stroke="{border}" />
+  <rect x="1" y="1" width="378" height="208" rx="14" fill="{background}" stroke="{border}" />
 
-  <rect x="20" y="20" width="64" height="64" rx="12" fill="{panel_soft}" stroke="{border}" />
+  <rect x="18" y="18" width="54" height="54" rx="14" fill="{panel_soft}" stroke="{border}" />
   <image
     href="{avatar_url}"
-    x="20"
-    y="20"
-    width="64"
-    height="64"
+    x="18"
+    y="18"
+    width="54"
+    height="54"
     preserveAspectRatio="xMidYMid slice"
     clip-path="url(#avatarClip)"
   />
 
-  <circle cx="78" cy="78" r="9" fill="{background}" />
-  <circle cx="78" cy="78" r="6" fill="{status_accent}" stroke="{panel}" stroke-width="1.5" />
+  <circle cx="64" cy="64" r="9" fill="{background}" />
+  <circle cx="64" cy="64" r="6" fill="{status_accent}" stroke="{panel}" stroke-width="1.5" />
 
-  <text x="100" y="36" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12" font-weight="600">@{username}</text>
-  <text x="100" y="58" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">{display_name}</text>
+  <text x="86" y="40" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">{display_name}</text>
+  <text x="86" y="60" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12.5" font-weight="500">{username}</text>
 
-  <!-- pushed HR down -->
-  <line x1="20" y1="110" x2="400" y2="110" stroke="{border}" stroke-width="1" />
+  <line x1="6" y1="95" x2="374" y2="95" stroke="{border}" stroke-width="1" />
 
-  <!-- more breathing room -->
-  <text x="20" y="132" fill="{body}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14">{activity}</text>
-  <text x="20" y="148" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11">{footer}</text>
+{activity_asset_markup}{activity_small_asset_markup}  <text x="{text_x}" y="{activity_label_y}" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.4px">{activity_name}</text>
+  <text x="{text_x}" y="{activity_title_y}" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="14.5" font-weight="700">{activity}</text>
+{secondary_svg}
+{elapsed_svg}
 </svg>"#,
         display_name = escaped_display_name,
         desc = escaped_desc,
+        activity_asset_x = activity_asset_x,
+        activity_asset_y = activity_asset_y,
+        activity_asset_size = activity_asset_size,
+        activity_asset_radius = activity_asset_radius,
+        small_asset_x = small_asset_x,
+        small_asset_y = small_asset_y,
+        small_asset_size = small_asset_size,
+        small_asset_radius = small_asset_radius,
         background = background,
         border = palette.border,
         panel = palette.panel,
-        panel_soft = palette.panel_soft,
         avatar_url = escaped_avatar_url,
         status_accent = status_accent,
         username = escaped_username,
         title_color = palette.title,
         muted = palette.muted,
-        body = palette.body,
+        activity_asset_markup = activity_asset_markup,
+        activity_small_asset_markup = activity_small_asset_markup,
+        text_x = text_x,
+        activity_label_y = activity_label_y,
+        activity_title_y = activity_title_y,
+        activity_name = escaped_activity_name,
         activity = escaped_activity,
-        footer = escaped_footer,
+        secondary_svg = secondary_svg,
+        elapsed_svg = elapsed_svg,
+        panel_soft = palette.panel_soft,
     )
 }
 
@@ -506,12 +665,59 @@ fn discord_avatar_url(user: &DiscordUserSummary) -> String {
     )
 }
 
-fn primary_activity_line(payload: &PresencePayload, idle_message: Option<&str>) -> String {
-    if let Some(spotify) = payload.presence.spotify.as_ref() {
-        return format!("Listening to {}", spotify.song);
+fn widget_uses_spotify(payload: &PresencePayload) -> bool {
+    payload.presence.spotify.is_some()
+}
+
+fn widget_spotify_activity(payload: &PresencePayload) -> Option<&ActivitySummary> {
+    payload.presence.activities.iter().find(|activity| {
+        activity.kind == "listening" || activity.name.eq_ignore_ascii_case("spotify")
+    })
+}
+
+fn widget_discord_activity(payload: &PresencePayload) -> Option<&ActivitySummary> {
+    payload.presence.activities.iter().find(|activity| {
+        activity.kind != "custom"
+            && activity.kind != "listening"
+            && !activity.name.eq_ignore_ascii_case("spotify")
+    })
+}
+
+fn widget_activity_name(payload: &PresencePayload) -> String {
+    if widget_uses_spotify(payload) {
+        return "Spotify".to_string();
     }
 
-    if let Some(activity) = rich_activity(payload) {
+    widget_discord_activity(payload)
+        .and_then(|activity| non_empty(Some(activity.name.as_str())))
+        .unwrap_or("Current activity")
+        .to_string()
+}
+
+fn widget_activity_asset_url(payload: &PresencePayload) -> Option<String> {
+    if widget_uses_spotify(payload) {
+        return widget_spotify_activity(payload).and_then(activity_asset_image_url);
+    }
+
+    widget_discord_activity(payload).and_then(activity_asset_image_url)
+}
+
+fn widget_activity_small_asset_url(payload: &PresencePayload) -> Option<String> {
+    if widget_uses_spotify(payload) {
+        return widget_spotify_activity(payload).and_then(activity_small_asset_image_url);
+    }
+
+    widget_discord_activity(payload).and_then(activity_small_asset_image_url)
+}
+
+fn primary_activity_line(payload: &PresencePayload, idle_message: Option<&str>) -> String {
+    if widget_uses_spotify(payload) {
+        if let Some(spotify) = payload.presence.spotify.as_ref() {
+            return format!("Listening to {}", spotify.song);
+        }
+    }
+
+    if let Some(activity) = widget_discord_activity(payload) {
         return format_primary_activity(activity);
     }
 
@@ -524,54 +730,124 @@ fn primary_activity_line(payload: &PresencePayload, idle_message: Option<&str>) 
         .to_string()
 }
 
-fn secondary_activity_line(payload: &PresencePayload, status_line: &str) -> String {
-    if let Some(spotify) = payload.presence.spotify.as_ref() {
-        return match spotify.album.as_deref() {
-            Some(album) if !album.trim().is_empty() => {
-                format!("{} • {}", spotify.artist, album)
+fn secondary_activity_lines(payload: &PresencePayload, status_line: &str) -> Vec<String> {
+    if widget_uses_spotify(payload) {
+        if let Some(spotify) = payload.presence.spotify.as_ref() {
+            let mut lines = Vec::new();
+
+            if !spotify.artist.trim().is_empty() {
+                lines.push(format!("By {}", spotify.artist));
             }
-            _ => spotify.artist.clone(),
-        };
+
+            if let Some(album) = spotify
+                .album
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+            {
+                lines.push(format!("on {}", album));
+            }
+
+            return lines;
+        }
     }
 
-    if let Some(activity) = rich_activity(payload) {
-        if let Some(context) = activity_context_line(activity) {
+    if let Some(activity) = widget_discord_activity(payload) {
+        if let Some(context) = activity_context_lines(activity) {
             return context;
         }
 
         if let Some(custom) = custom_status_text(payload) {
-            return custom;
+            return vec![custom];
         }
 
-        return format!(
-            "{} • {}",
-            pretty_activity_kind(&activity.kind),
-            activity.name
-        );
+        return vec![
+            pretty_activity_kind(&activity.kind).to_string(),
+            activity.name.clone(),
+        ];
     }
 
     if let Some(custom) = custom_status_text(payload) {
-        return custom;
+        return vec![custom];
     }
 
     if payload.kv.is_empty() {
-        status_line.to_string()
-    } else {
+        if status_line.trim().is_empty() {
+            return Vec::new();
+        }
+
+        return vec![status_line.to_string()];
+    }
+
+    vec![
+        status_line.to_string(),
         format!(
-            "{} • {} KV entr{}",
-            status_line,
+            "{} KV entr{}",
             payload.kv.len(),
             if payload.kv.len() == 1 { "y" } else { "ies" }
-        )
-    }
+        ),
+    ]
 }
 
-fn rich_activity(payload: &PresencePayload) -> Option<&ActivitySummary> {
-    payload
-        .presence
-        .activities
-        .iter()
-        .find(|activity| activity.kind != "custom")
+fn activity_asset_image_url(activity: &ActivitySummary) -> Option<String> {
+    let assets = activity.assets.as_ref()?;
+    let large_image = non_empty(assets.large_image.as_deref())?;
+
+    if let Some(url) = spotify_image_url(large_image) {
+        return Some(url);
+    }
+
+    if let Some(path) = large_image.strip_prefix("mp:") {
+        return Some(format!(
+            "https://media.discordapp.net/{}",
+            path.trim_start_matches('/')
+        ));
+    }
+
+    if large_image.starts_with("https://") || large_image.starts_with("http://") {
+        return Some(large_image.to_string());
+    }
+
+    activity
+        .application_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|application_id| {
+            format!(
+                "https://cdn.discordapp.com/app-assets/{}/{}.png",
+                application_id, large_image
+            )
+        })
+}
+
+fn activity_small_asset_image_url(activity: &ActivitySummary) -> Option<String> {
+    let assets = activity.assets.as_ref()?;
+    let small_image = non_empty(assets.small_image.as_deref())?;
+
+    if let Some(url) = spotify_image_url(small_image) {
+        return Some(url);
+    }
+
+    if let Some(path) = small_image.strip_prefix("mp:") {
+        return Some(format!(
+            "https://media.discordapp.net/{}",
+            path.trim_start_matches('/')
+        ));
+    }
+
+    if small_image.starts_with("https://") || small_image.starts_with("http://") {
+        return Some(small_image.to_string());
+    }
+
+    activity
+        .application_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .map(|application_id| {
+            format!(
+                "https://cdn.discordapp.com/app-assets/{}/{}.png",
+                application_id, small_image
+            )
+        })
 }
 
 fn custom_status_text(payload: &PresencePayload) -> Option<String> {
@@ -613,15 +889,61 @@ fn format_primary_activity(activity: &ActivitySummary) -> String {
         .unwrap_or_else(|| pretty_activity_kind(&activity.kind).to_string())
 }
 
-fn activity_context_line(activity: &ActivitySummary) -> Option<String> {
+fn activity_context_lines(activity: &ActivitySummary) -> Option<Vec<String>> {
     match (
         non_empty(activity.details.as_deref()),
         non_empty(activity.state.as_deref()),
     ) {
-        (Some(details), Some(state)) => Some(format!("{} • {}", details, state)),
-        (Some(details), None) => Some(details.to_string()),
-        (None, Some(state)) => Some(state.to_string()),
+        (Some(details), Some(state)) => Some(vec![details.to_string(), state.to_string()]),
+        (Some(details), None) => Some(vec![details.to_string()]),
+        (None, Some(state)) => Some(vec![state.to_string()]),
         (None, None) => None,
+    }
+}
+
+fn elapsed_activity_line(payload: &PresencePayload) -> Option<String> {
+    if widget_uses_spotify(payload) {
+        if let Some(spotify) = payload.presence.spotify.as_ref() {
+            if let Some(start) = spotify.timestamps.as_ref().and_then(|value| value.start) {
+                return Some(format!(
+                    "Elapsed {}",
+                    format_elapsed_from_unix_millis(start as i64)
+                ));
+            }
+        }
+
+        return None;
+    }
+
+    if let Some(activity) = widget_discord_activity(payload) {
+        if let Some(start) = activity.timestamps.as_ref().and_then(|value| value.start) {
+            return Some(format!(
+                "Elapsed {}",
+                format_elapsed_from_unix_millis(start as i64)
+            ));
+        }
+    }
+
+    None
+}
+
+fn format_elapsed_from_unix_millis(start_ms: i64) -> String {
+    let now_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(start_ms);
+
+    let elapsed_ms = now_ms.saturating_sub(start_ms);
+    let total_seconds = (elapsed_ms / 1000).max(0);
+
+    let hours = total_seconds / 3600;
+    let minutes = (total_seconds % 3600) / 60;
+    let seconds = total_seconds % 60;
+
+    if hours > 0 {
+        format!("{hours}:{minutes:02}:{seconds:02}")
+    } else {
+        format!("{minutes}:{seconds:02}")
     }
 }
 

--- a/src/routes/presence.rs
+++ b/src/routes/presence.rs
@@ -422,6 +422,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
     };
 
     let display_name = truncate(&preferred_display_name(&payload.presence.discord_user), 24);
+    let custom_status_header = custom_status_text(payload).map(|value| truncate(&value, 30));
 
     let activity_line = truncate(
         &primary_activity_line(payload, query.idle_message.as_deref()),
@@ -449,6 +450,16 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
     let escaped_activity = escape_html(&activity_line);
     let escaped_desc = escape_attr(&activity_line);
     let escaped_activity_name = escape_html(&activity_name.to_uppercase());
+    let custom_status_svg = custom_status_header
+        .as_ref()
+        .map(|value| {
+            format!(
+                r#"  <text x="86" y="78" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="11.5" font-weight="500">{value}</text>"#,
+                muted = palette.muted,
+                value = escape_html(value),
+            )
+        })
+        .unwrap_or_default();
 
     let activity_label_y = 126;
     let activity_title_y = 146;
@@ -605,7 +616,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
 
   <text x="86" y="40" fill="{title_color}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="18" font-weight="700">{display_name}</text>
   <text x="86" y="60" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="12.5" font-weight="500">{username}</text>
-
+{custom_status_svg}
   <line x1="6" y1="95" x2="374" y2="95" stroke="{border}" stroke-width="1" />
 
 {activity_asset_markup}{activity_small_asset_markup}  <text x="{text_x}" y="{activity_label_y}" fill="{muted}" font-family="Inter, Segoe UI, Arial, sans-serif" font-size="10.5" font-weight="700" letter-spacing="0.4px">{activity_name}</text>
@@ -633,6 +644,7 @@ fn render_widget_svg(payload: &PresencePayload, query: &WidgetQuery) -> String {
         muted = palette.muted,
         activity_asset_markup = activity_asset_markup,
         activity_small_asset_markup = activity_small_asset_markup,
+        custom_status_svg = custom_status_svg,
         text_x = text_x,
         activity_label_y = activity_label_y,
         activity_title_y = activity_title_y,

--- a/src/routes/presence.rs
+++ b/src/routes/presence.rs
@@ -918,7 +918,7 @@ fn elapsed_activity_line(payload: &PresencePayload) -> Option<String> {
         if let Some(spotify) = payload.presence.spotify.as_ref() {
             if let Some(start) = spotify.timestamps.as_ref().and_then(|value| value.start) {
                 return Some(format!(
-                    "Elapsed {}",
+                    "{} elapsed",
                     format_elapsed_from_unix_millis(start as i64)
                 ));
             }
@@ -930,7 +930,7 @@ fn elapsed_activity_line(payload: &PresencePayload) -> Option<String> {
     if let Some(activity) = widget_discord_activity(payload) {
         if let Some(start) = activity.timestamps.as_ref().and_then(|value| value.start) {
             return Some(format!(
-                "Elapsed {}",
+                "{} elapsed",
                 format_elapsed_from_unix_millis(start as i64)
             ));
         }


### PR DESCRIPTION
This PR introduces a new Discord Presence service to VoidChan, inspired by [Lanyard](https://github.com/Phineas/lanyard), enabling real-time access to user presence data, including activities and status.

With this addition, users can:

- Retrieve live Discord presence data via API (`/api/discord/:user_id`)
- Attach custom key-value metadata to their presence (KV storage system up to 512 keys per user for extensibility and personalisation)
- Render a dynamic SVG widget showcasing their current activity (e.g. Spotify, games, custom status) (`/api/discord/:user_id/widget.svg`)

